### PR TITLE
Add Taproot Assets support

### DIFF
--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -2,4 +2,5 @@ export { default as LndApi } from './lnd';
 export { default as LoopApi } from './loop';
 export { default as PoolApi } from './pool';
 export { default as FaradayApi } from './faraday';
+export { default as TaprootAssetsApi } from './tapd';
 export { default as LitApi } from './lit';

--- a/lib/api/tapd.ts
+++ b/lib/api/tapd.ts
@@ -1,0 +1,24 @@
+import { serviceNames as sn } from '../types/proto/schema';
+import { AssetWallet } from '../types/proto/tapd/assetwalletrpc/assetwallet';
+import { Mint } from '../types/proto/tapd/mintrpc/mint';
+import { TaprootAssets } from '../types/proto/tapd/taprootassets';
+import { Universe } from '../types/proto/tapd/universerpc/universe';
+
+/**
+ * An API wrapper to communicate with the Taproot Assets node via GRPC
+ */
+class TaprootAssetsApi {
+    taprootAssets: TaprootAssets;
+    assetWallet: AssetWallet;
+    mint: Mint;
+    universe: Universe;
+
+    constructor(createRpc: Function, lnc: any) {
+        this.taprootAssets = createRpc(sn.taprpc.TaprootAssets, lnc);
+        this.mint = createRpc(sn.mintrpc.Mint, lnc);
+        this.assetWallet = createRpc(sn.assetwalletrpc.AssetWallet, lnc);
+        this.universe = createRpc(sn.universerpc.Universe, lnc);
+    }
+}
+
+export default TaprootAssetsApi;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,11 @@
 export * from './types/proto';
 export { camelKeysToSnake, isObject, snakeKeysToCamel } from './util/objects';
-export { LndApi, LoopApi, PoolApi, FaradayApi, LitApi } from './api';
+export {
+    LndApi,
+    LoopApi,
+    PoolApi,
+    FaradayApi,
+    LitApi,
+    TaprootAssetsApi
+} from './api';
 export { subscriptionMethods } from './types/proto/schema';

--- a/lib/types/proto/assetwalletrpc.ts
+++ b/lib/types/proto/assetwalletrpc.ts
@@ -1,0 +1,1 @@
+export * from './tapd/assetwalletrpc/assetwallet';

--- a/lib/types/proto/index.ts
+++ b/lib/types/proto/index.ts
@@ -11,6 +11,10 @@ import * as watchtowerrpc from './watchtowerrpc';
 import * as wtclientrpc from './wtclientrpc';
 import * as looprpc from './looprpc';
 import * as poolrpc from './poolrpc';
+import * as assetwalletrpc from './assetwalletrpc';
+import * as mintrpc from './mintrpc';
+import * as taprpc from './taprpc';
+import * as universerpc from './universerpc';
 export {
     frdrpc,
     litrpc,
@@ -24,5 +28,9 @@ export {
     watchtowerrpc,
     wtclientrpc,
     looprpc,
-    poolrpc
+    poolrpc,
+    assetwalletrpc,
+    mintrpc,
+    taprpc,
+    universerpc
 };

--- a/lib/types/proto/mintrpc.ts
+++ b/lib/types/proto/mintrpc.ts
@@ -1,0 +1,1 @@
+export * from './tapd/mintrpc/mint';

--- a/lib/types/proto/schema.ts
+++ b/lib/types/proto/schema.ts
@@ -27,7 +27,11 @@ export const serviceNames = {
         ChannelAuctioneer: 'poolrpc.ChannelAuctioneer',
         HashMail: 'poolrpc.HashMail',
         Trader: 'poolrpc.Trader'
-    }
+    },
+    assetwalletrpc: { AssetWallet: 'assetwalletrpc.AssetWallet' },
+    mintrpc: { Mint: 'mintrpc.Mint' },
+    taprpc: { TaprootAssets: 'taprpc.TaprootAssets' },
+    universerpc: { Universe: 'universerpc.Universe' }
 };
 
 // This array contains the list of methods that are server streaming. It is
@@ -64,5 +68,6 @@ export const subscriptionMethods = [
     'looprpc.SwapClient.Monitor',
     'poolrpc.ChannelAuctioneer.SubscribeBatchAuction',
     'poolrpc.ChannelAuctioneer.SubscribeSidecar',
-    'poolrpc.HashMail.RecvStream'
+    'poolrpc.HashMail.RecvStream',
+    'taprpc.TaprootAssets.SubscribeSendAssetEventNtfns'
 ];

--- a/lib/types/proto/tapd/assetwalletrpc/assetwallet.ts
+++ b/lib/types/proto/tapd/assetwalletrpc/assetwallet.ts
@@ -1,0 +1,205 @@
+/* eslint-disable */
+import type {
+    KeyDescriptor,
+    ScriptKey,
+    SendAssetResponse
+} from '../taprootassets';
+
+export interface FundVirtualPsbtRequest {
+    /**
+     * Use an existing PSBT packet as the template for the funded PSBT.
+     *
+     * TODO(guggero): Actually implement this. We can't use the "reserved"
+     * keyword here because we're in a oneof, so we add the field but implement
+     * it later.
+     */
+    psbt: Uint8Array | string | undefined;
+    /** Use the asset outputs and optional asset inputs from this raw template. */
+    raw: TxTemplate | undefined;
+}
+
+export interface FundVirtualPsbtResponse {
+    /** The funded but not yet signed PSBT packet. */
+    fundedPsbt: Uint8Array | string;
+    /** The index of the added change output or -1 if no change was left over. */
+    changeOutputIndex: number;
+}
+
+export interface TxTemplate {
+    /**
+     * An optional list of inputs to use. Every input must be an asset UTXO known
+     * to the wallet. The sum of all inputs must be greater than or equal to the
+     * sum of all outputs.
+     *
+     * If no inputs are specified, asset coin selection will be performed instead
+     * and inputs of sufficient value will be added to the resulting PSBT.
+     */
+    inputs: PrevId[];
+    /**
+     * A map of all Taproot Asset addresses mapped to the anchor transaction's
+     * output index that should be sent to.
+     */
+    recipients: { [key: string]: string };
+}
+
+export interface TxTemplate_RecipientsEntry {
+    key: string;
+    value: string;
+}
+
+export interface PrevId {
+    /** The bitcoin anchor output on chain that contains the input asset. */
+    outpoint: OutPoint | undefined;
+    /** The asset ID of the previous asset tree. */
+    id: Uint8Array | string;
+    /**
+     * The tweaked Taproot output key committing to the possible spending
+     * conditions of the asset.
+     */
+    scriptKey: Uint8Array | string;
+}
+
+export interface OutPoint {
+    /** Raw bytes representing the transaction id. */
+    txid: Uint8Array | string;
+    /** The index of the output on the transaction. */
+    outputIndex: number;
+}
+
+export interface SignVirtualPsbtRequest {
+    /**
+     * The PSBT of the virtual transaction that should be signed. The PSBT must
+     * contain all required inputs, outputs, UTXO data and custom fields required
+     * to identify the signing key.
+     */
+    fundedPsbt: Uint8Array | string;
+}
+
+export interface SignVirtualPsbtResponse {
+    /** The signed virtual transaction in PSBT format. */
+    signedPsbt: Uint8Array | string;
+    /** The indices of signed inputs. */
+    signedInputs: number[];
+}
+
+export interface AnchorVirtualPsbtsRequest {
+    /**
+     * The list of virtual transactions that should be merged and committed to in
+     * the BTC level anchor transaction.
+     */
+    virtualPsbts: Uint8Array | string[];
+}
+
+export interface NextInternalKeyRequest {
+    keyFamily: number;
+}
+
+export interface NextInternalKeyResponse {
+    internalKey: KeyDescriptor | undefined;
+}
+
+export interface NextScriptKeyRequest {
+    keyFamily: number;
+}
+
+export interface NextScriptKeyResponse {
+    scriptKey: ScriptKey | undefined;
+}
+
+export interface ProveAssetOwnershipRequest {
+    assetId: Uint8Array | string;
+    scriptKey: Uint8Array | string;
+}
+
+export interface ProveAssetOwnershipResponse {
+    proofWithWitness: Uint8Array | string;
+}
+
+export interface VerifyAssetOwnershipRequest {
+    proofWithWitness: Uint8Array | string;
+}
+
+export interface VerifyAssetOwnershipResponse {
+    validProof: boolean;
+}
+
+export interface AssetWallet {
+    /**
+     * FundVirtualPsbt selects inputs from the available asset commitments to fund
+     * a virtual transaction matching the template.
+     */
+    fundVirtualPsbt(
+        request?: DeepPartial<FundVirtualPsbtRequest>
+    ): Promise<FundVirtualPsbtResponse>;
+    /**
+     * SignVirtualPsbt signs the inputs of a virtual transaction and prepares the
+     * commitments of the inputs and outputs.
+     */
+    signVirtualPsbt(
+        request?: DeepPartial<SignVirtualPsbtRequest>
+    ): Promise<SignVirtualPsbtResponse>;
+    /**
+     * AnchorVirtualPsbts merges and then commits multiple virtual transactions in
+     * a single BTC level anchor transaction.
+     *
+     * TODO(guggero): Actually implement accepting and merging multiple
+     * transactions.
+     */
+    anchorVirtualPsbts(
+        request?: DeepPartial<AnchorVirtualPsbtsRequest>
+    ): Promise<SendAssetResponse>;
+    /**
+     * NextInternalKey derives the next internal key for the given key family and
+     * stores it as an internal key in the database to make sure it is identified
+     * as a local key later on when importing proofs. While an internal key can
+     * also be used as the internal key of a script key, it is recommended to use
+     * the NextScriptKey RPC instead, to make sure the tweaked Taproot output key
+     * is also recognized as a local key.
+     */
+    nextInternalKey(
+        request?: DeepPartial<NextInternalKeyRequest>
+    ): Promise<NextInternalKeyResponse>;
+    /**
+     * NextScriptKey derives the next script key (and its corresponding internal
+     * key) and stores them both in the database to make sure they are identified
+     * as local keys later on when importing proofs.
+     */
+    nextScriptKey(
+        request?: DeepPartial<NextScriptKeyRequest>
+    ): Promise<NextScriptKeyResponse>;
+    /**
+     * ProveAssetOwnership creates an ownership proof embedded in an asset
+     * transition proof. That ownership proof is a signed virtual transaction
+     * spending the asset with a valid witness to prove the prover owns the keys
+     * that can spend the asset.
+     */
+    proveAssetOwnership(
+        request?: DeepPartial<ProveAssetOwnershipRequest>
+    ): Promise<ProveAssetOwnershipResponse>;
+    /**
+     * VerifyAssetOwnership verifies the asset ownership proof embedded in the
+     * given transition proof of an asset and returns true if the proof is valid.
+     */
+    verifyAssetOwnership(
+        request?: DeepPartial<VerifyAssetOwnershipRequest>
+    ): Promise<VerifyAssetOwnershipResponse>;
+}
+
+type Builtin =
+    | Date
+    | Function
+    | Uint8Array
+    | string
+    | number
+    | boolean
+    | undefined;
+
+type DeepPartial<T> = T extends Builtin
+    ? T
+    : T extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepPartial<U>>
+    : T extends {}
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : Partial<T>;

--- a/lib/types/proto/tapd/mintrpc/mint.ts
+++ b/lib/types/proto/tapd/mintrpc/mint.ts
@@ -1,0 +1,145 @@
+/* eslint-disable */
+import type { AssetType, AssetMeta } from '../taprootassets';
+
+export enum BatchState {
+    BATCH_STATE_UNKNOWN = 'BATCH_STATE_UNKNOWN',
+    BATCH_STATE_PEDNING = 'BATCH_STATE_PEDNING',
+    BATCH_STATE_FROZEN = 'BATCH_STATE_FROZEN',
+    BATCH_STATE_COMMITTED = 'BATCH_STATE_COMMITTED',
+    BATCH_STATE_BROADCAST = 'BATCH_STATE_BROADCAST',
+    BATCH_STATE_CONFIRMED = 'BATCH_STATE_CONFIRMED',
+    BATCH_STATE_FINALIZED = 'BATCH_STATE_FINALIZED',
+    BATCH_STATE_SEEDLING_CANCELLED = 'BATCH_STATE_SEEDLING_CANCELLED',
+    BATCH_STATE_SPROUT_CANCELLED = 'BATCH_STATE_SPROUT_CANCELLED',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+export interface MintAsset {
+    /** The type of the asset to be created. */
+    assetType: AssetType;
+    /** The name, or "tag" of the asset. This will affect the final asset ID. */
+    name: string;
+    /**
+     * A blob that resents metadata related to the asset. This will affect the
+     * final asset ID.
+     */
+    assetMeta: AssetMeta | undefined;
+    /**
+     * The total amount of units of the new asset that should be created. If the
+     * AssetType is Collectible, then this field cannot be set.
+     */
+    amount: string;
+    /** The specific group key this asset should be minted with. */
+    groupKey: Uint8Array | string;
+    /**
+     * The name of the asset in the batch that will anchor a new asset group.
+     * This asset will be minted with the same group key as the anchor asset.
+     */
+    groupAnchor: string;
+}
+
+export interface MintAssetRequest {
+    /** The asset to be minted. */
+    asset: MintAsset | undefined;
+    /**
+     * If true, then the asset will be created with a group key, which allows for
+     * future asset issuance.
+     */
+    enableEmission: boolean;
+}
+
+export interface MintAssetResponse {
+    /**
+     * A public key serialized in compressed format that can be used to uniquely
+     * identify a pending minting batch. Responses that share the same key will be
+     * batched into the same minting transaction.
+     */
+    batchKey: Uint8Array | string;
+}
+
+export interface MintingBatch {
+    /** The internal public key of the batch. */
+    batchKey: Uint8Array | string;
+    /** The assets that are part of the batch. */
+    assets: MintAsset[];
+    /** The state of the batch. */
+    state: BatchState;
+}
+
+export interface FinalizeBatchRequest {}
+
+export interface FinalizeBatchResponse {
+    /** The internal public key of the batch. */
+    batchKey: Uint8Array | string;
+}
+
+export interface CancelBatchRequest {}
+
+export interface CancelBatchResponse {
+    /** The internal public key of the batch. */
+    batchKey: Uint8Array | string;
+}
+
+export interface ListBatchRequest {
+    /**
+     * The optional batch key of the batch to list. When using REST this field
+     * must be encoded as base64url.
+     */
+    batchKey: Uint8Array | string;
+}
+
+export interface ListBatchResponse {
+    batches: MintingBatch[];
+}
+
+export interface Mint {
+    /**
+     * tapcli: `assets mint`
+     * MintAsset will attempt to mint the set of assets (async by default to
+     * ensure proper batching) specified in the request.
+     */
+    mintAsset(
+        request?: DeepPartial<MintAssetRequest>
+    ): Promise<MintAssetResponse>;
+    /**
+     * tapcli: `assets mint finalize`
+     * FinalizeBatch will attempt to finalize the current pending batch.
+     */
+    finalizeBatch(
+        request?: DeepPartial<FinalizeBatchRequest>
+    ): Promise<FinalizeBatchResponse>;
+    /**
+     * tapcli: `assets mint cancel`
+     * CancelBatch will attempt to cancel the current pending batch.
+     */
+    cancelBatch(
+        request?: DeepPartial<CancelBatchRequest>
+    ): Promise<CancelBatchResponse>;
+    /**
+     * tapcli: `assets mint batches`
+     * ListBatches lists the set of batches submitted to the daemon, including
+     * pending and cancelled batches.
+     */
+    listBatches(
+        request?: DeepPartial<ListBatchRequest>
+    ): Promise<ListBatchResponse>;
+}
+
+type Builtin =
+    | Date
+    | Function
+    | Uint8Array
+    | string
+    | number
+    | boolean
+    | undefined;
+
+type DeepPartial<T> = T extends Builtin
+    ? T
+    : T extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepPartial<U>>
+    : T extends {}
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : Partial<T>;

--- a/lib/types/proto/tapd/taprootassets.ts
+++ b/lib/types/proto/tapd/taprootassets.ts
@@ -1,0 +1,758 @@
+/* eslint-disable */
+
+export enum AssetType {
+    /**
+     * NORMAL - Indicates that an asset is capable of being split/merged, with each of the
+     * units being fungible, even across a key asset ID boundary (assuming the
+     * key group is the same).
+     */
+    NORMAL = 'NORMAL',
+    /**
+     * COLLECTIBLE - Indicates that an asset is a collectible, meaning that each of the other
+     * items under the same key group are not fully fungible with each other.
+     * Collectibles also cannot be split or merged.
+     */
+    COLLECTIBLE = 'COLLECTIBLE',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+export enum AssetMetaType {
+    /**
+     * MTEA_TYPE_OPAQUE - Opaque is used for asset meta blobs that have no true structure and instead
+     * should be interpreted as opaque blobs.
+     */
+    MTEA_TYPE_OPAQUE = 'MTEA_TYPE_OPAQUE',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+export enum OutputType {
+    /**
+     * OUTPUT_TYPE_SIMPLE - OUTPUT_TYPE_SIMPLE is a plain full-value or split output that is not a
+     * split root and does not carry passive assets. In case of a split, the
+     * asset of this output has a split commitment.
+     */
+    OUTPUT_TYPE_SIMPLE = 'OUTPUT_TYPE_SIMPLE',
+    /**
+     * OUTPUT_TYPE_SPLIT_ROOT - OUTPUT_TYPE_SPLIT_ROOT is a split root output that carries the change
+     * from a split or a tombstone from a non-interactive full value send
+     * output. In either case, the asset of this output has a tx witness.
+     */
+    OUTPUT_TYPE_SPLIT_ROOT = 'OUTPUT_TYPE_SPLIT_ROOT',
+    /**
+     * OUTPUT_TYPE_PASSIVE_ASSETS_ONLY - OUTPUT_TYPE_PASSIVE_ASSETS_ONLY indicates that this output only carries
+     * passive assets and therefore the asset in this output is nil. The passive
+     * assets themselves are signed in their own virtual transactions and
+     * are not present in this packet.
+     */
+    OUTPUT_TYPE_PASSIVE_ASSETS_ONLY = 'OUTPUT_TYPE_PASSIVE_ASSETS_ONLY',
+    /**
+     * OUTPUT_TYPE_PASSIVE_SPLIT_ROOT - OUTPUT_TYPE_PASSIVE_SPLIT_ROOT is a split root output that carries the
+     * change from a split or a tombstone from a non-interactive full value send
+     * output, as well as passive assets.
+     */
+    OUTPUT_TYPE_PASSIVE_SPLIT_ROOT = 'OUTPUT_TYPE_PASSIVE_SPLIT_ROOT',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+export enum AddrEventStatus {
+    ADDR_EVENT_STATUS_UNKNOWN = 'ADDR_EVENT_STATUS_UNKNOWN',
+    ADDR_EVENT_STATUS_TRANSACTION_DETECTED = 'ADDR_EVENT_STATUS_TRANSACTION_DETECTED',
+    ADDR_EVENT_STATUS_TRANSACTION_CONFIRMED = 'ADDR_EVENT_STATUS_TRANSACTION_CONFIRMED',
+    ADDR_EVENT_STATUS_PROOF_RECEIVED = 'ADDR_EVENT_STATUS_PROOF_RECEIVED',
+    ADDR_EVENT_STATUS_COMPLETED = 'ADDR_EVENT_STATUS_COMPLETED',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+export interface AssetMeta {
+    /**
+     * The raw data of the asset meta data. Based on the type below, this may be
+     * structured data such as a text file or PDF.
+     */
+    data: Uint8Array | string;
+    /** The type of the asset meta data. */
+    type: AssetMetaType;
+    /**
+     * The hash of the meta. This is the hash of the TLV serialization of the meta
+     * itself.
+     */
+    metaHash: Uint8Array | string;
+}
+
+export interface ListAssetRequest {
+    withWitness: boolean;
+    includeSpent: boolean;
+}
+
+export interface AnchorInfo {
+    /**
+     * The transaction that anchors the Taproot Asset commitment where the asset
+     *  resides.
+     */
+    anchorTx: Uint8Array | string;
+    /** The txid of the above transaction. */
+    anchorTxid: string;
+    /** The block hash the contains the anchor transaction above. */
+    anchorBlockHash: Uint8Array | string;
+    /** The outpoint (txid:vout) that stores the Taproot Asset commitment. */
+    anchorOutpoint: string;
+    /** The raw internal key that was used to create the anchor Taproot output key. */
+    internalKey: Uint8Array | string;
+    /**
+     * The Taproot merkle root hash of the anchor output the asset was committed
+     * to. If there is no Tapscript sibling, this is equal to the Taproot Asset
+     * root commitment hash.
+     */
+    merkleRoot: Uint8Array | string;
+    /**
+     * The serialized preimage of a Tapscript sibling, if there was one. If this
+     * is empty, then the merkle_root hash is equal to the Taproot root hash of the
+     * anchor output.
+     */
+    tapscriptSibling: Uint8Array | string;
+}
+
+export interface GenesisInfo {
+    /** The first outpoint of the transaction that created the asset (txid:vout). */
+    genesisPoint: string;
+    /** The name of the asset. */
+    name: string;
+    /** The hash of the meta data for this genesis asset. */
+    metaHash: Uint8Array | string;
+    /** The asset ID that uniquely identifies the asset. */
+    assetId: Uint8Array | string;
+    /**
+     * The index of the output that carries the unique Taproot Asset commitment in
+     * the genesis transaction.
+     */
+    outputIndex: number;
+    /** The version of the Taproot Asset commitment that created this asset. */
+    version: number;
+}
+
+export interface AssetGroup {
+    /** The raw group key which is a normal public key. */
+    rawGroupKey: Uint8Array | string;
+    /**
+     * The tweaked group key, which is derived based on the genesis point and also
+     * asset type.
+     */
+    tweakedGroupKey: Uint8Array | string;
+    /** A signature over the genesis point using the above key. */
+    assetIdSig: Uint8Array | string;
+}
+
+export interface Asset {
+    /** The version of the Taproot Asset. */
+    version: number;
+    /** The base genesis information of an asset. This information never changes. */
+    assetGenesis: GenesisInfo | undefined;
+    /** The type of the asset. */
+    assetType: AssetType;
+    /** The total amount of the asset stored in this Taproot Asset UTXO. */
+    amount: string;
+    /** An optional locktime, as with Bitcoin transactions. */
+    lockTime: number;
+    /** An optional relative lock time, same as Bitcoin transactions. */
+    relativeLockTime: number;
+    /** The version of the script, only version 0 is defined at present. */
+    scriptVersion: number;
+    /** The script key of the asset, which can be spent under Taproot semantics. */
+    scriptKey: Uint8Array | string;
+    /**
+     * Indicates whether the script key is known to the wallet of the lnd node
+     * connected to the Taproot Asset daemon.
+     */
+    scriptKeyIsLocal: boolean;
+    /** The information related to the key group of an asset (if it exists). */
+    assetGroup: AssetGroup | undefined;
+    /** Describes where in the chain the asset is currently anchored. */
+    chainAnchor: AnchorInfo | undefined;
+    prevWitnesses: PrevWitness[];
+    /** Indicates whether the asset has been spent. */
+    isSpent: boolean;
+}
+
+export interface PrevWitness {
+    prevId: PrevInputAsset | undefined;
+    txWitness: Uint8Array | string[];
+    splitCommitment: SplitCommitment | undefined;
+}
+
+export interface SplitCommitment {
+    rootAsset: Asset | undefined;
+}
+
+export interface ListAssetResponse {
+    assets: Asset[];
+}
+
+export interface ListUtxosRequest {}
+
+export interface ManagedUtxo {
+    /** The outpoint of the UTXO. */
+    outPoint: string;
+    /** The UTXO amount in satoshis. */
+    amtSat: string;
+    /** The internal key used for the on-chain output. */
+    internalKey: Uint8Array | string;
+    /** The Taproot Asset root commitment hash. */
+    taprootAssetRoot: Uint8Array | string;
+    /**
+     * The Taproot merkle root hash committed to by the outpoint of this UTXO.
+     * If there is no Tapscript sibling, this is equal to the Taproot Asset root
+     * commitment hash.
+     */
+    merkleRoot: Uint8Array | string;
+    /** The assets held at this UTXO. */
+    assets: Asset[];
+}
+
+export interface ListUtxosResponse {
+    /** The set of UTXOs managed by the daemon. */
+    managedUtxos: { [key: string]: ManagedUtxo };
+}
+
+export interface ListUtxosResponse_ManagedUtxosEntry {
+    key: string;
+    value: ManagedUtxo | undefined;
+}
+
+export interface ListGroupsRequest {}
+
+export interface AssetHumanReadable {
+    /** The ID of the asset. */
+    id: Uint8Array | string;
+    /** The amount of the asset. */
+    amount: string;
+    /** An optional locktime, as with Bitcoin transactions. */
+    lockTime: number;
+    /** An optional relative locktime, as with Bitcoin transactions. */
+    relativeLockTime: number;
+    /** The name of the asset. */
+    tag: string;
+    /** The metadata hash of the asset. */
+    metaHash: Uint8Array | string;
+    /** The type of the asset. */
+    type: AssetType;
+}
+
+export interface GroupedAssets {
+    /** A list of assets with the same group key. */
+    assets: AssetHumanReadable[];
+}
+
+export interface ListGroupsResponse {
+    /** The set of assets with a group key. */
+    groups: { [key: string]: GroupedAssets };
+}
+
+export interface ListGroupsResponse_GroupsEntry {
+    key: string;
+    value: GroupedAssets | undefined;
+}
+
+export interface ListBalancesRequest {
+    /** Group results by asset IDs. */
+    assetId: boolean | undefined;
+    /** Group results by group keys. */
+    groupKey: boolean | undefined;
+    /**
+     * If the query results should grouped by asset ids, then an optional asset
+     * filter may be provided to query balance of a specific asset.
+     */
+    assetFilter: Uint8Array | string;
+    /**
+     * If the query results should be grouped by group keys, then an optional
+     * group key filter may be provided to query the balance of a specific
+     * asset group.
+     */
+    groupKeyFilter: Uint8Array | string;
+}
+
+export interface AssetBalance {
+    /** The base genesis information of an asset. This information never changes. */
+    assetGenesis: GenesisInfo | undefined;
+    /** The type of the asset. */
+    assetType: AssetType;
+    /** The balance of the asset owned by the target daemon. */
+    balance: string;
+}
+
+export interface AssetGroupBalance {
+    /** The group key or nil aggregating assets that don't have a group. */
+    groupKey: Uint8Array | string;
+    /** The total balance of the assets in the group. */
+    balance: string;
+}
+
+export interface ListBalancesResponse {
+    assetBalances: { [key: string]: AssetBalance };
+    assetGroupBalances: { [key: string]: AssetGroupBalance };
+}
+
+export interface ListBalancesResponse_AssetBalancesEntry {
+    key: string;
+    value: AssetBalance | undefined;
+}
+
+export interface ListBalancesResponse_AssetGroupBalancesEntry {
+    key: string;
+    value: AssetGroupBalance | undefined;
+}
+
+export interface ListTransfersRequest {}
+
+export interface ListTransfersResponse {
+    /** The unordered list of outgoing asset transfers. */
+    transfers: AssetTransfer[];
+}
+
+export interface AssetTransfer {
+    transferTimestamp: string;
+    /**
+     * The new transaction that commits to the set of Taproot Assets found
+     * at the above new anchor point.
+     */
+    anchorTxHash: Uint8Array | string;
+    anchorTxHeightHint: number;
+    anchorTxChainFees: string;
+    /** Describes the set of spent assets. */
+    inputs: TransferInput[];
+    /** Describes the set of newly created asset outputs. */
+    outputs: TransferOutput[];
+}
+
+export interface TransferInput {
+    /**
+     * The old/current location of the Taproot Asset commitment that was spent
+     * as an input.
+     */
+    anchorPoint: string;
+    /** The ID of the asset that was spent. */
+    assetId: Uint8Array | string;
+    /** The script key of the asset that was spent. */
+    scriptKey: Uint8Array | string;
+    /** The amount of the asset that was spent. */
+    amount: string;
+}
+
+export interface TransferOutputAnchor {
+    /**
+     * The new location of the Taproot Asset commitment that was created on
+     * chain.
+     */
+    outpoint: string;
+    value: string;
+    internalKey: Uint8Array | string;
+    taprootAssetRoot: Uint8Array | string;
+    merkleRoot: Uint8Array | string;
+    tapscriptSibling: Uint8Array | string;
+    numPassiveAssets: number;
+}
+
+export interface TransferOutput {
+    anchor: TransferOutputAnchor | undefined;
+    scriptKey: Uint8Array | string;
+    scriptKeyIsLocal: boolean;
+    amount: string;
+    newProofBlob: Uint8Array | string;
+    splitCommitRootHash: Uint8Array | string;
+    outputType: OutputType;
+}
+
+export interface StopRequest {}
+
+export interface StopResponse {}
+
+export interface DebugLevelRequest {
+    /** If true, all the valid debug sub-systems will be returned. */
+    show: boolean;
+    levelSpec: string;
+}
+
+export interface DebugLevelResponse {
+    subSystems: string;
+}
+
+export interface Addr {
+    /** The bech32 encoded Taproot Asset address. */
+    encoded: string;
+    /** The asset ID that uniquely identifies the asset. */
+    assetId: Uint8Array | string;
+    /** The type of the asset. */
+    assetType: AssetType;
+    /** The total amount of the asset stored in this Taproot Asset UTXO. */
+    amount: string;
+    /** The group key of the asset (if it exists) */
+    groupKey: Uint8Array | string;
+    /**
+     * The specific script key the asset must commit to in order to transfer
+     * ownership to the creator of the address.
+     */
+    scriptKey: Uint8Array | string;
+    /** The internal key used for the on-chain output. */
+    internalKey: Uint8Array | string;
+    /**
+     * The optional serialized tapscript sibling preimage to use for the receiving
+     * asset. This is usually empty as it is only needed when there should be an
+     * additional script path in the Taproot tree alongside the Taproot Asset
+     * commitment of the asset.
+     */
+    tapscriptSibling: Uint8Array | string;
+    /**
+     * The tweaked internal key that commits to the asset and represents the
+     * on-chain output key the Bitcoin transaction must send to in order to
+     * transfer assets described in this address.
+     */
+    taprootOutputKey: Uint8Array | string;
+}
+
+export interface QueryAddrRequest {
+    /**
+     * If set, then only addresses created after this Unix timestamp will be
+     * returned.
+     */
+    createdAfter: string;
+    /**
+     * If set, then only addresses created before this Unix timestamp will be
+     * returned.
+     */
+    createdBefore: string;
+    /** The max number of addresses that should be returned. */
+    limit: number;
+    /** The offset from the addresses that should be returned. */
+    offset: number;
+}
+
+export interface QueryAddrResponse {
+    addrs: Addr[];
+}
+
+export interface NewAddrRequest {
+    assetId: Uint8Array | string;
+    amt: string;
+    /**
+     * The optional script key that the receiving asset should be locked to. If no
+     * script key is provided, a normal BIP-86 key will be derived from the
+     * underlying wallet.
+     *
+     * NOTE: The script_key and internal_key fields should either both be set or
+     * both be empty.
+     */
+    scriptKey: ScriptKey | undefined;
+    /**
+     * The optional internal key of the receiving BTC level transaction output on
+     * which the receiving asset transfers will be committed to. If no internal key
+     * is provided, a key will be derived from the underlying wallet.
+     *
+     * NOTE: The script_key and internal_key fields should either both be set or
+     * both be empty.
+     */
+    internalKey: KeyDescriptor | undefined;
+    /**
+     * The optional serialized tapscript sibling preimage to use for the receiving
+     * asset. This is usually empty as it is only needed when there should be an
+     * additional script path in the Taproot tree alongside the Taproot Asset
+     * commitment of the asset.
+     */
+    tapscriptSibling: Uint8Array | string;
+}
+
+export interface ScriptKey {
+    /**
+     * The full Taproot output key the asset is locked to. This is either a BIP-86
+     * key if the tap_tweak below is empty, or a key with the tap tweak applied to
+     * it.
+     */
+    pubKey: Uint8Array | string;
+    /** The key descriptor describing the internal key of the above Taproot key. */
+    keyDesc: KeyDescriptor | undefined;
+    /**
+     * The optional Taproot tweak to apply to the above internal key. If this is
+     * empty then a BIP-86 style tweak is applied to the internal key.
+     */
+    tapTweak: Uint8Array | string;
+}
+
+export interface KeyLocator {
+    /** The family of key being identified. */
+    keyFamily: number;
+    /** The precise index of the key being identified. */
+    keyIndex: number;
+}
+
+export interface KeyDescriptor {
+    /** The raw bytes of the key being identified. */
+    rawKeyBytes: Uint8Array | string;
+    /** The key locator that identifies which key to use for signing. */
+    keyLoc: KeyLocator | undefined;
+}
+
+export interface DecodeAddrRequest {
+    addr: string;
+}
+
+export interface ProofFile {
+    rawProof: Uint8Array | string;
+    genesisPoint: string;
+}
+
+export interface ProofVerifyResponse {
+    valid: boolean;
+}
+
+export interface ExportProofRequest {
+    assetId: Uint8Array | string;
+    scriptKey: Uint8Array | string;
+}
+
+export interface ImportProofRequest {
+    proofFile: Uint8Array | string;
+    genesisPoint: string;
+}
+
+export interface ImportProofResponse {}
+
+export interface AddrEvent {
+    /** The time the event was created in unix timestamp seconds. */
+    creationTimeUnixSeconds: string;
+    /** The address the event was created for. */
+    addr: Addr | undefined;
+    /** The current status of the event. */
+    status: AddrEventStatus;
+    /** The outpoint that contains the inbound asset transfer. */
+    outpoint: string;
+    /**
+     * The amount in satoshis that were transferred on chain along with the asset.
+     * This amount is independent of the requested asset amount, which can be
+     * looked up on the address.
+     */
+    utxoAmtSat: string;
+    /** The taproot sibling hash that was used to send to the Taproot output. */
+    taprootSibling: Uint8Array | string;
+    /**
+     * The height at which the on-chain output was confirmed. If this is zero, it
+     * means the output is unconfirmed.
+     */
+    confirmationHeight: number;
+    /**
+     * Indicates whether a proof file can be found for the address' asset ID and
+     * script key.
+     */
+    hasProof: boolean;
+}
+
+export interface AddrReceivesRequest {
+    /** Filter receives by a specific address. Leave empty to get all receives. */
+    filterAddr: string;
+    /** Filter receives by a specific status. Leave empty to get all receives. */
+    filterStatus: AddrEventStatus;
+}
+
+export interface AddrReceivesResponse {
+    /** The events that match the filter criteria. */
+    events: AddrEvent[];
+}
+
+export interface SendAssetRequest {
+    tapAddrs: string[];
+}
+
+export interface PrevInputAsset {
+    anchorPoint: string;
+    assetId: Uint8Array | string;
+    scriptKey: Uint8Array | string;
+    amount: string;
+}
+
+export interface SendAssetResponse {
+    transfer: AssetTransfer | undefined;
+}
+
+export interface SubscribeSendAssetEventNtfnsRequest {}
+
+export interface SendAssetEvent {
+    /** An event which indicates that a send state is about to be executed. */
+    executeSendStateEvent: ExecuteSendStateEvent | undefined;
+    /**
+     * An event which indicates that the proof send backoff wait period will
+     * start imminently.
+     */
+    receiverProofBackoffWaitEvent: ReceiverProofBackoffWaitEvent | undefined;
+}
+
+export interface ExecuteSendStateEvent {
+    /** Execute timestamp (microseconds). */
+    timestamp: string;
+    /** The send state that is about to be executed. */
+    sendState: string;
+}
+
+export interface ReceiverProofBackoffWaitEvent {
+    /** Transfer attempt timestamp (microseconds). */
+    timestamp: string;
+    /** Backoff is the active backoff wait duration. */
+    backoff: string;
+    /**
+     * Tries counter is the number of tries we've made so far during the
+     * course of the current backoff procedure to deliver the proof to the
+     * receiver.
+     */
+    triesCounter: string;
+}
+
+export interface FetchAssetMetaRequest {
+    /** The asset ID of the asset to fetch the meta for. */
+    assetId: Uint8Array | string | undefined;
+    /** The 32-byte meta hash of the asset meta. */
+    metaHash: Uint8Array | string | undefined;
+}
+
+export interface TaprootAssets {
+    /**
+     * tapcli: `assets list`
+     * ListAssets lists the set of assets owned by the target daemon.
+     */
+    listAssets(
+        request?: DeepPartial<ListAssetRequest>
+    ): Promise<ListAssetResponse>;
+    /**
+     * tapcli: `assets utxos`
+     * ListUtxos lists the UTXOs managed by the target daemon, and the assets they
+     * hold.
+     */
+    listUtxos(
+        request?: DeepPartial<ListUtxosRequest>
+    ): Promise<ListUtxosResponse>;
+    /**
+     * tapcli: `assets groups`
+     * ListGroups lists the asset groups known to the target daemon, and the assets
+     * held in each group.
+     */
+    listGroups(
+        request?: DeepPartial<ListGroupsRequest>
+    ): Promise<ListGroupsResponse>;
+    /**
+     * tapcli: `assets balance`
+     * ListBalances lists asset balances
+     */
+    listBalances(
+        request?: DeepPartial<ListBalancesRequest>
+    ): Promise<ListBalancesResponse>;
+    /**
+     * tapcli: `assets transfers`
+     * ListTransfers lists outbound asset transfers tracked by the target daemon.
+     */
+    listTransfers(
+        request?: DeepPartial<ListTransfersRequest>
+    ): Promise<ListTransfersResponse>;
+    /**
+     * tapcli: `stop`
+     * StopDaemon will send a shutdown request to the interrupt handler, triggering
+     * a graceful shutdown of the daemon.
+     */
+    stopDaemon(request?: DeepPartial<StopRequest>): Promise<StopResponse>;
+    /**
+     * tapcli: `debuglevel`
+     * DebugLevel allows a caller to programmatically set the logging verbosity of
+     * tapd. The logging can be targeted according to a coarse daemon-wide logging
+     * level, or in a granular fashion to specify the logging for a target
+     * sub-system.
+     */
+    debugLevel(
+        request?: DeepPartial<DebugLevelRequest>
+    ): Promise<DebugLevelResponse>;
+    /**
+     * tapcli: `addrs query`
+     * QueryAddrs queries the set of Taproot Asset addresses stored in the
+     * database.
+     */
+    queryAddrs(
+        request?: DeepPartial<QueryAddrRequest>
+    ): Promise<QueryAddrResponse>;
+    /**
+     * tapcli: `addrs new`
+     * NewAddr makes a new address from the set of request params.
+     */
+    newAddr(request?: DeepPartial<NewAddrRequest>): Promise<Addr>;
+    /**
+     * tapcli: `addrs decode`
+     * DecodeAddr decode a Taproot Asset address into a partial asset message that
+     * represents the asset it wants to receive.
+     */
+    decodeAddr(request?: DeepPartial<DecodeAddrRequest>): Promise<Addr>;
+    /**
+     * tapcli: `addrs receives`
+     * List all receives for incoming asset transfers for addresses that were
+     * created previously.
+     */
+    addrReceives(
+        request?: DeepPartial<AddrReceivesRequest>
+    ): Promise<AddrReceivesResponse>;
+    /**
+     * tapcli: `proofs verify`
+     * VerifyProof attempts to verify a given proof file that claims to be anchored
+     * at the specified genesis point.
+     */
+    verifyProof(request?: DeepPartial<ProofFile>): Promise<ProofVerifyResponse>;
+    /**
+     * tapcli: `proofs export`
+     * ExportProof exports the latest raw proof file anchored at the specified
+     * script_key.
+     */
+    exportProof(request?: DeepPartial<ExportProofRequest>): Promise<ProofFile>;
+    /**
+     * tapcli: `proofs import`
+     * ImportProof attempts to import a proof file into the daemon. If successful,
+     * a new asset will be inserted on disk, spendable using the specified target
+     * script key, and internal key.
+     */
+    importProof(
+        request?: DeepPartial<ImportProofRequest>
+    ): Promise<ImportProofResponse>;
+    /**
+     * tapcli: `assets send`
+     * SendAsset uses one or multiple passed Taproot Asset address(es) to attempt
+     * to complete an asset send. The method returns information w.r.t the on chain
+     * send, as well as the proof file information the receiver needs to fully
+     * receive the asset.
+     */
+    sendAsset(
+        request?: DeepPartial<SendAssetRequest>
+    ): Promise<SendAssetResponse>;
+    /**
+     * SubscribeSendAssetEventNtfns registers a subscription to the event
+     * notification stream which relates to the asset sending process.
+     */
+    subscribeSendAssetEventNtfns(
+        request?: DeepPartial<SubscribeSendAssetEventNtfnsRequest>,
+        onMessage?: (msg: SendAssetEvent) => void,
+        onError?: (err: Error) => void
+    ): void;
+    /**
+     * FetchAssetMeta allows a caller to fetch the reveal meta data for an asset
+     * either by the asset ID for that asset, or a meta hash.
+     */
+    fetchAssetMeta(
+        request?: DeepPartial<FetchAssetMetaRequest>
+    ): Promise<AssetMeta>;
+}
+
+type Builtin =
+    | Date
+    | Function
+    | Uint8Array
+    | string
+    | number
+    | boolean
+    | undefined;
+
+type DeepPartial<T> = T extends Builtin
+    ? T
+    : T extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepPartial<U>>
+    : T extends {}
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : Partial<T>;

--- a/lib/types/proto/tapd/universerpc/universe.ts
+++ b/lib/types/proto/tapd/universerpc/universe.ts
@@ -1,0 +1,366 @@
+/* eslint-disable */
+import type { AssetType, Asset } from '../taprootassets';
+
+export enum UniverseSyncMode {
+    /**
+     * SYNC_ISSUANCE_ONLY - A sync node that indicates that only new asset creation (minting) proofs
+     * should be synced.
+     */
+    SYNC_ISSUANCE_ONLY = 'SYNC_ISSUANCE_ONLY',
+    /**
+     * SYNC_FULL - A syncing mode that indicates that all asset proofs should be synced.
+     * This includes normal transfers as well.
+     */
+    SYNC_FULL = 'SYNC_FULL',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+export enum AssetQuerySort {
+    SORT_BY_NONE = 'SORT_BY_NONE',
+    SORT_BY_ASSET_NAME = 'SORT_BY_ASSET_NAME',
+    SORT_BY_ASSET_ID = 'SORT_BY_ASSET_ID',
+    SORT_BY_ASSET_TYPE = 'SORT_BY_ASSET_TYPE',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+export enum AssetTypeFilter {
+    FILTER_ASSET_NONE = 'FILTER_ASSET_NONE',
+    FILTER_ASSET_NORMAL = 'FILTER_ASSET_NORMAL',
+    FILTER_ASSET_COLLECTIBLE = 'FILTER_ASSET_COLLECTIBLE',
+    UNRECOGNIZED = 'UNRECOGNIZED'
+}
+
+/** TODO(roasbeef): filter by asset ID, etc? */
+export interface AssetRootRequest {}
+
+export interface MerkleSumNode {
+    /** The MS-SMT root hash for the branch node. */
+    rootHash: Uint8Array | string;
+    /**
+     * The root sum of the branch node. This is hashed to create the root_hash
+     * along with the left and right siblings. This value represents the total
+     * known supply of the asset.
+     */
+    rootSum: string;
+}
+
+export interface ID {
+    /** The 32-byte asset ID. */
+    assetId: Uint8Array | string | undefined;
+    /** The 32-byte asset ID encoded as a hex string. */
+    assetIdStr: string | undefined;
+    /** The 32-byte asset group key. */
+    groupKey: Uint8Array | string | undefined;
+    /** The 32-byte asset group key encoded as hex string. */
+    groupKeyStr: string | undefined;
+}
+
+export interface UniverseRoot {
+    id: ID | undefined;
+    /**
+     * The merkle sum sparse merkle tree root associated with the above
+     * universe ID.
+     */
+    mssmtRoot: MerkleSumNode | undefined;
+    /** The name of the asset. */
+    assetName: string;
+}
+
+export interface AssetRootResponse {
+    /**
+     * A map of the set of known universe roots for each asset. The key in the
+     * map is the 32-byte asset_id or group key hash.
+     */
+    universeRoots: { [key: string]: UniverseRoot };
+}
+
+export interface AssetRootResponse_UniverseRootsEntry {
+    key: string;
+    value: UniverseRoot | undefined;
+}
+
+export interface AssetRootQuery {
+    /** An ID value to uniquely identify a Universe root. */
+    id: ID | undefined;
+}
+
+export interface QueryRootResponse {
+    /** The asset root for the given asset ID or group key. */
+    assetRoot: UniverseRoot | undefined;
+}
+
+export interface Outpoint {
+    /** The output as a hex encoded (and reversed!) string. */
+    hashStr: string;
+    /** The index of the output. */
+    index: number;
+}
+
+export interface AssetKey {
+    opStr: string | undefined;
+    op: Outpoint | undefined;
+    scriptKeyBytes: Uint8Array | string | undefined;
+    scriptKeyStr: string | undefined;
+}
+
+export interface AssetLeafKeyResponse {
+    /** The set of asset leaf keys for the given asset ID or group key. */
+    assetKeys: AssetKey[];
+}
+
+export interface AssetLeaf {
+    /** The asset included in the leaf. */
+    asset: Asset | undefined;
+    /**
+     * The asset issuance proof, which proves that the asset specified above
+     * was issued properly.
+     */
+    issuanceProof: Uint8Array | string;
+}
+
+export interface AssetLeafResponse {
+    /** The set of asset leaves for the given asset ID or group key. */
+    leaves: AssetLeaf[];
+}
+
+export interface UniverseKey {
+    /** The ID of the asset to query for. */
+    id: ID | undefined;
+    /** The asset key to query for. */
+    leafKey: AssetKey | undefined;
+}
+
+export interface AssetProofResponse {
+    /** The request original request for the issuance proof. */
+    req: UniverseKey | undefined;
+    /** The Universe root that includes this asset leaf. */
+    universeRoot: UniverseRoot | undefined;
+    /**
+     * An inclusion proof for the asset leaf included below. The value is that
+     * issuance proof itself, with a sum value of the amount of the asset.
+     */
+    universeInclusionProof: Uint8Array | string;
+    /** The asset leaf itself, which includes the asset and the issuance proof. */
+    assetLeaf: AssetLeaf | undefined;
+}
+
+export interface AssetProof {
+    /** The ID of the asset to insert the proof for. */
+    key: UniverseKey | undefined;
+    /** The asset leaf to insert into the Universe tree. */
+    assetLeaf: AssetLeaf | undefined;
+}
+
+export interface SyncTarget {
+    id: ID | undefined;
+}
+
+export interface SyncRequest {
+    /**
+     * TODO(roasbeef): accept connection type? so can pass along self-signed
+     * cert, also brontide based RPC handshake
+     */
+    universeHost: string;
+    /** The sync mode. This determines what type of proofs are synced. */
+    syncMode: UniverseSyncMode;
+    /**
+     * The set of assets to sync. If none are specified, then all assets are
+     * synced.
+     */
+    syncTargets: SyncTarget[];
+}
+
+export interface SyncedUniverse {
+    /** The old Universe root for the synced asset. */
+    oldAssetRoot: UniverseRoot | undefined;
+    /** The new Universe root for the synced asset. */
+    newAssetRoot: UniverseRoot | undefined;
+    /** The set of new asset leaves that were synced. */
+    newAssetLeaves: AssetLeaf[];
+}
+
+export interface StatsRequest {}
+
+export interface SyncResponse {
+    /** The set of synced asset Universes. */
+    syncedUniverses: SyncedUniverse[];
+}
+
+export interface UniverseFederationServer {
+    host: string;
+    id: number;
+}
+
+export interface ListFederationServersRequest {}
+
+export interface ListFederationServersResponse {
+    servers: UniverseFederationServer[];
+}
+
+export interface AddFederationServerRequest {
+    servers: UniverseFederationServer[];
+}
+
+export interface AddFederationServerResponse {}
+
+export interface DeleteFederationServerRequest {
+    servers: UniverseFederationServer[];
+}
+
+export interface DeleteFederationServerResponse {}
+
+export interface StatsResponse {
+    numTotalAssets: string;
+    numTotalSyncs: string;
+    numTotalProofs: string;
+}
+
+export interface AssetStatsQuery {
+    assetNameFilter: string;
+    assetIdFilter: Uint8Array | string;
+    assetTypeFilter: AssetTypeFilter;
+    sortBy: AssetQuerySort;
+    offset: number;
+    limit: number;
+}
+
+export interface AssetStatsSnapshot {
+    assetId: Uint8Array | string;
+    totalSupply: string;
+    assetName: string;
+    assetType: AssetType;
+    genesisHeight: number;
+    totalSyncs: string;
+    totalProofs: string;
+}
+
+export interface UniverseAssetStats {
+    assetStats: AssetStatsSnapshot[];
+}
+
+export interface Universe {
+    /**
+     * tapcli: `universe roots`
+     * AssetRoots queries for the known Universe roots associated with each known
+     * asset. These roots represent the supply/audit state for each known asset.
+     */
+    assetRoots(
+        request?: DeepPartial<AssetRootRequest>
+    ): Promise<AssetRootResponse>;
+    /**
+     * tapcli: `universe roots`
+     * QueryAssetRoots attempts to locate the current Universe root for a specific
+     * asset. This asset can be identified by its asset ID or group key.
+     */
+    queryAssetRoots(
+        request?: DeepPartial<AssetRootQuery>
+    ): Promise<QueryRootResponse>;
+    /**
+     * tapcli: `universe keys`
+     * AssetLeafKeys queries for the set of Universe keys associated with a given
+     * asset_id or group_key. Each key takes the form: (outpoint, script_key),
+     * where outpoint is an outpoint in the Bitcoin blockcahin that anchors a
+     * valid Taproot Asset commitment, and script_key is the script_key of
+     * the asset within the Taproot Asset commitment for the given asset_id or
+     * group_key.
+     */
+    assetLeafKeys(request?: DeepPartial<ID>): Promise<AssetLeafKeyResponse>;
+    /**
+     * tapcli: `universe leaves`
+     * AssetLeaves queries for the set of asset leaves (the values in the Universe
+     * MS-SMT tree) for a given asset_id or group_key. These represents either
+     * asset issuance events (they have a genesis witness) or asset transfers that
+     * took place on chain. The leaves contain a normal Taproot Asset proof, as
+     * well as details for the asset.
+     */
+    assetLeaves(request?: DeepPartial<ID>): Promise<AssetLeafResponse>;
+    /**
+     * tapcli: `universe proofs query`
+     * QueryProof attempts to query for an issuance or transfer proof for a given
+     * asset based on its UniverseKey. A UniverseKey is composed of the Universe
+     * ID (asset_id/group_key) and also a leaf key (outpoint || script_key). If
+     * found, then the issuance proof is returned that includes an inclusion proof
+     * to the known Universe root, as well as a Taproot Asset state transition or
+     * issuance proof for the said asset.
+     */
+    queryProof(request?: DeepPartial<UniverseKey>): Promise<AssetProofResponse>;
+    /**
+     * tapcli: `universe proofs insert`
+     * InsertProof attempts to insert a new issuance or transfer proof into the
+     * Universe tree specified by the UniverseKey. If valid, then the proof is
+     * inserted into the database, with a new Universe root returned for the
+     * updated asset_id/group_key.
+     */
+    insertProof(request?: DeepPartial<AssetProof>): Promise<AssetProofResponse>;
+    /**
+     * tapcli: `universe sync`
+     * SyncUniverse takes host information for a remote Universe server, then
+     * attempts to synchronize either only the set of specified asset_ids, or all
+     * assets if none are specified. The sync process will attempt to query for
+     * the latest known root for each asset, performing tree based reconciliation
+     * to arrive at a new shared root.
+     */
+    syncUniverse(request?: DeepPartial<SyncRequest>): Promise<SyncResponse>;
+    /**
+     * tapcli: `universe federation list`
+     * ListFederationServers lists the set of servers that make up the federation
+     * of the local Universe server. This servers are used to push out new proofs,
+     * and also periodically call sync new proofs from the remote server.
+     */
+    listFederationServers(
+        request?: DeepPartial<ListFederationServersRequest>
+    ): Promise<ListFederationServersResponse>;
+    /**
+     * tapcli: `universe federation add`
+     * AddFederationServer adds a new server to the federation of the local
+     * Universe server. Once a server is added, this call can also optionally be
+     * used to trigger a sync of the remote server.
+     */
+    addFederationServer(
+        request?: DeepPartial<AddFederationServerRequest>
+    ): Promise<AddFederationServerResponse>;
+    /**
+     * tapcli: `universe federation del`
+     * DeleteFederationServer removes a server from the federation of the local
+     * Universe server.
+     */
+    deleteFederationServer(
+        request?: DeepPartial<DeleteFederationServerRequest>
+    ): Promise<DeleteFederationServerResponse>;
+    /**
+     * tapcli: `universe stats`
+     * UniverseStats returns a set of aggregrate statistics for the current state
+     * of the Universe. Stats returned include: total number of syncs, total
+     * number of proofs, and total number of known assets.
+     */
+    universeStats(request?: DeepPartial<StatsRequest>): Promise<StatsResponse>;
+    /**
+     * tapcli `universe stats assets`
+     * QueryAssetStats returns a set of statistics for a given set of assets.
+     * Stats can be queried for all assets, or based on the: asset ID, name, or
+     * asset type. Pagination is supported via the offset and limit params.
+     * Results can also be sorted based on any of the main query params.
+     */
+    queryAssetStats(
+        request?: DeepPartial<AssetStatsQuery>
+    ): Promise<UniverseAssetStats>;
+}
+
+type Builtin =
+    | Date
+    | Function
+    | Uint8Array
+    | string
+    | number
+    | boolean
+    | undefined;
+
+type DeepPartial<T> = T extends Builtin
+    ? T
+    : T extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepPartial<U>>
+    : T extends {}
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : Partial<T>;

--- a/lib/types/proto/taprpc.ts
+++ b/lib/types/proto/taprpc.ts
@@ -1,0 +1,1 @@
+export * from './tapd/taprootassets';

--- a/lib/types/proto/universerpc.ts
+++ b/lib/types/proto/universerpc.ts
@@ -1,0 +1,1 @@
+export * from './tapd/universerpc/universe';

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "loop_release_tag": "v0.22.0-beta",
     "pool_release_tag": "v0.6.2-beta",
     "faraday_release_tag": "v0.2.9-alpha",
+    "tapd_release_tag": "v0.2.0-lit-0",
     "lit_release_tag": "v0.9.0-alpha",
     "protoc_version": "21.9"
   },
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "dev": "webpack --watch --stats-error-details",
-    "update-protos": "sh scripts/update_protos.sh  ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_lit_release_tag}",
+    "update-protos": "sh scripts/update_protos.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_tapd_release_tag} ${npm_package_config_lit_release_tag}",
     "generate": "sh scripts/generate_types.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_lit_release_tag} ${npm_package_config_protoc_version}",
     "prettier": "prettier --check '**/*.ts*'",
     "prettier-write": "prettier --check --write '**/*.ts*'",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "NODE_ENV=production webpack",
     "dev": "webpack --watch --stats-error-details",
     "update-protos": "sh scripts/update_protos.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_tapd_release_tag} ${npm_package_config_lit_release_tag}",
-    "generate": "sh scripts/generate_types.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_lit_release_tag} ${npm_package_config_protoc_version}",
+    "generate": "sh scripts/generate_types.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_tapd_release_tag} ${npm_package_config_lit_release_tag} ${npm_package_config_protoc_version}",
     "prettier": "prettier --check '**/*.ts*'",
     "prettier-write": "prettier --check --write '**/*.ts*'",
     "lint": "tslint -p tsconfig.json",

--- a/protos/tapd/v0.2.0-lit-0/assetwalletrpc/assetwallet.proto
+++ b/protos/tapd/v0.2.0-lit-0/assetwalletrpc/assetwallet.proto
@@ -1,0 +1,208 @@
+syntax = "proto3";
+
+import "taprootassets.proto";
+
+package assetwalletrpc;
+
+option go_package = "github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc";
+
+service AssetWallet {
+    /*
+    FundVirtualPsbt selects inputs from the available asset commitments to fund
+    a virtual transaction matching the template.
+    */
+    rpc FundVirtualPsbt (FundVirtualPsbtRequest)
+        returns (FundVirtualPsbtResponse);
+
+    /*
+    SignVirtualPsbt signs the inputs of a virtual transaction and prepares the
+    commitments of the inputs and outputs.
+    */
+    rpc SignVirtualPsbt (SignVirtualPsbtRequest)
+        returns (SignVirtualPsbtResponse);
+
+    /*
+    AnchorVirtualPsbts merges and then commits multiple virtual transactions in
+    a single BTC level anchor transaction.
+
+    TODO(guggero): Actually implement accepting and merging multiple
+    transactions.
+    */
+    rpc AnchorVirtualPsbts (AnchorVirtualPsbtsRequest)
+        returns (taprpc.SendAssetResponse);
+
+    /*
+    NextInternalKey derives the next internal key for the given key family and
+    stores it as an internal key in the database to make sure it is identified
+    as a local key later on when importing proofs. While an internal key can
+    also be used as the internal key of a script key, it is recommended to use
+    the NextScriptKey RPC instead, to make sure the tweaked Taproot output key
+    is also recognized as a local key.
+    */
+    rpc NextInternalKey (NextInternalKeyRequest)
+        returns (NextInternalKeyResponse);
+
+    /*
+    NextScriptKey derives the next script key (and its corresponding internal
+    key) and stores them both in the database to make sure they are identified
+    as local keys later on when importing proofs.
+    */
+    rpc NextScriptKey (NextScriptKeyRequest) returns (NextScriptKeyResponse);
+
+    /*
+    ProveAssetOwnership creates an ownership proof embedded in an asset
+    transition proof. That ownership proof is a signed virtual transaction
+    spending the asset with a valid witness to prove the prover owns the keys
+    that can spend the asset.
+    */
+    rpc ProveAssetOwnership (ProveAssetOwnershipRequest)
+        returns (ProveAssetOwnershipResponse);
+
+    /*
+    VerifyAssetOwnership verifies the asset ownership proof embedded in the
+    given transition proof of an asset and returns true if the proof is valid.
+    */
+    rpc VerifyAssetOwnership (VerifyAssetOwnershipRequest)
+        returns (VerifyAssetOwnershipResponse);
+}
+
+message FundVirtualPsbtRequest {
+    oneof template {
+        /*
+        Use an existing PSBT packet as the template for the funded PSBT.
+
+        TODO(guggero): Actually implement this. We can't use the "reserved"
+        keyword here because we're in a oneof, so we add the field but implement
+        it later.
+        */
+        bytes psbt = 1;
+
+        /*
+        Use the asset outputs and optional asset inputs from this raw template.
+        */
+        TxTemplate raw = 2;
+    }
+}
+
+message FundVirtualPsbtResponse {
+    /*
+    The funded but not yet signed PSBT packet.
+    */
+    bytes funded_psbt = 1;
+
+    /*
+    The index of the added change output or -1 if no change was left over.
+    */
+    int32 change_output_index = 2;
+}
+
+message TxTemplate {
+    /*
+    An optional list of inputs to use. Every input must be an asset UTXO known
+    to the wallet. The sum of all inputs must be greater than or equal to the
+    sum of all outputs.
+
+    If no inputs are specified, asset coin selection will be performed instead
+    and inputs of sufficient value will be added to the resulting PSBT.
+    */
+    repeated PrevId inputs = 1;
+
+    /*
+    A map of all Taproot Asset addresses mapped to the anchor transaction's
+    output index that should be sent to.
+    */
+    map<string, uint64> recipients = 2;
+}
+
+message PrevId {
+    /*
+    The bitcoin anchor output on chain that contains the input asset.
+    */
+    OutPoint outpoint = 1;
+
+    /*
+    The asset ID of the previous asset tree.
+    */
+    bytes id = 2;
+
+    /*
+    The tweaked Taproot output key committing to the possible spending
+    conditions of the asset.
+    */
+    bytes script_key = 3;
+}
+
+message OutPoint {
+    /*
+    Raw bytes representing the transaction id.
+    */
+    bytes txid = 1;
+
+    /*
+    The index of the output on the transaction.
+    */
+    uint32 output_index = 2;
+}
+
+message SignVirtualPsbtRequest {
+    /*
+    The PSBT of the virtual transaction that should be signed. The PSBT must
+    contain all required inputs, outputs, UTXO data and custom fields required
+    to identify the signing key.
+    */
+    bytes funded_psbt = 1;
+}
+
+message SignVirtualPsbtResponse {
+    /*
+    The signed virtual transaction in PSBT format.
+    */
+    bytes signed_psbt = 1;
+
+    /*
+    The indices of signed inputs.
+    */
+    repeated uint32 signed_inputs = 2;
+}
+
+message AnchorVirtualPsbtsRequest {
+    /*
+    The list of virtual transactions that should be merged and committed to in
+    the BTC level anchor transaction.
+    */
+    repeated bytes virtual_psbts = 1;
+}
+
+message NextInternalKeyRequest {
+    uint32 key_family = 1;
+}
+
+message NextInternalKeyResponse {
+    taprpc.KeyDescriptor internal_key = 1;
+}
+
+message NextScriptKeyRequest {
+    uint32 key_family = 1;
+}
+
+message NextScriptKeyResponse {
+    taprpc.ScriptKey script_key = 1;
+}
+
+message ProveAssetOwnershipRequest {
+    bytes asset_id = 1;
+
+    bytes script_key = 2;
+}
+
+message ProveAssetOwnershipResponse {
+    bytes proof_with_witness = 1;
+}
+
+message VerifyAssetOwnershipRequest {
+    bytes proof_with_witness = 1;
+}
+
+message VerifyAssetOwnershipResponse {
+    bool valid_proof = 1;
+}

--- a/protos/tapd/v0.2.0-lit-0/mintrpc/mint.proto
+++ b/protos/tapd/v0.2.0-lit-0/mintrpc/mint.proto
@@ -1,0 +1,133 @@
+syntax = "proto3";
+
+import "taprootassets.proto";
+
+package mintrpc;
+
+option go_package = "github.com/lightninglabs/taproot-assets/taprpc/mintrpc";
+
+service Mint {
+    /* tapcli: `assets mint`
+    MintAsset will attempt to mint the set of assets (async by default to
+    ensure proper batching) specified in the request.
+    */
+    rpc MintAsset (MintAssetRequest) returns (MintAssetResponse);
+
+    /* tapcli: `assets mint finalize`
+    FinalizeBatch will attempt to finalize the current pending batch.
+    */
+    rpc FinalizeBatch (FinalizeBatchRequest) returns (FinalizeBatchResponse);
+
+    /* tapcli: `assets mint cancel`
+    CancelBatch will attempt to cancel the current pending batch.
+    */
+    rpc CancelBatch (CancelBatchRequest) returns (CancelBatchResponse);
+
+    /* tapcli: `assets mint batches`
+    ListBatches lists the set of batches submitted to the daemon, including
+    pending and cancelled batches.
+    */
+    rpc ListBatches (ListBatchRequest) returns (ListBatchResponse);
+}
+
+message MintAsset {
+    // The type of the asset to be created.
+    taprpc.AssetType asset_type = 1;
+
+    // The name, or "tag" of the asset. This will affect the final asset ID.
+    string name = 2;
+
+    /*
+    A blob that resents metadata related to the asset. This will affect the
+    final asset ID.
+    */
+    taprpc.AssetMeta asset_meta = 3;
+
+    /*
+    The total amount of units of the new asset that should be created. If the
+    AssetType is Collectible, then this field cannot be set.
+    */
+    uint64 amount = 4;
+
+    /*
+    The specific group key this asset should be minted with.
+    */
+    bytes group_key = 5;
+
+    /*
+    The name of the asset in the batch that will anchor a new asset group.
+    This asset will be minted with the same group key as the anchor asset.
+    */
+    string group_anchor = 6;
+}
+
+message MintAssetRequest {
+    /*
+    The asset to be minted.
+    */
+    MintAsset asset = 1;
+
+    /*
+    If true, then the asset will be created with a group key, which allows for
+    future asset issuance.
+    */
+    bool enable_emission = 2;
+}
+
+message MintAssetResponse {
+    /*
+    A public key serialized in compressed format that can be used to uniquely
+    identify a pending minting batch. Responses that share the same key will be
+    batched into the same minting transaction.
+    */
+    bytes batch_key = 1;
+}
+
+message MintingBatch {
+    // The internal public key of the batch.
+    bytes batch_key = 1;
+
+    // The assets that are part of the batch.
+    repeated MintAsset assets = 2;
+
+    // The state of the batch.
+    BatchState state = 3;
+}
+
+enum BatchState {
+    BATCH_STATE_UNKNOWN = 0;
+    BATCH_STATE_PEDNING = 1;
+    BATCH_STATE_FROZEN = 2;
+    BATCH_STATE_COMMITTED = 3;
+    BATCH_STATE_BROADCAST = 4;
+    BATCH_STATE_CONFIRMED = 5;
+    BATCH_STATE_FINALIZED = 6;
+    BATCH_STATE_SEEDLING_CANCELLED = 7;
+    BATCH_STATE_SPROUT_CANCELLED = 8;
+}
+
+message FinalizeBatchRequest {
+}
+
+message FinalizeBatchResponse {
+    // The internal public key of the batch.
+    bytes batch_key = 1;
+}
+
+message CancelBatchRequest {
+}
+
+message CancelBatchResponse {
+    // The internal public key of the batch.
+    bytes batch_key = 1;
+}
+
+message ListBatchRequest {
+    // The optional batch key of the batch to list. When using REST this field
+    // must be encoded as base64url.
+    bytes batch_key = 1;
+}
+
+message ListBatchResponse {
+    repeated MintingBatch batches = 1;
+}

--- a/protos/tapd/v0.2.0-lit-0/taprootassets.proto
+++ b/protos/tapd/v0.2.0-lit-0/taprootassets.proto
@@ -1,0 +1,807 @@
+syntax = "proto3";
+
+package taprpc;
+
+option go_package = "github.com/lightninglabs/taproot-assets/taprpc";
+
+service TaprootAssets {
+    /* tapcli: `assets list`
+    ListAssets lists the set of assets owned by the target daemon.
+    */
+    rpc ListAssets (ListAssetRequest) returns (ListAssetResponse);
+
+    /* tapcli: `assets utxos`
+    ListUtxos lists the UTXOs managed by the target daemon, and the assets they
+    hold.
+    */
+    rpc ListUtxos (ListUtxosRequest) returns (ListUtxosResponse);
+
+    /* tapcli: `assets groups`
+    ListGroups lists the asset groups known to the target daemon, and the assets
+    held in each group.
+    */
+    rpc ListGroups (ListGroupsRequest) returns (ListGroupsResponse);
+
+    /* tapcli: `assets balance`
+    ListBalances lists asset balances
+    */
+    rpc ListBalances (ListBalancesRequest) returns (ListBalancesResponse);
+
+    /* tapcli: `assets transfers`
+    ListTransfers lists outbound asset transfers tracked by the target daemon.
+    */
+    rpc ListTransfers (ListTransfersRequest) returns (ListTransfersResponse);
+
+    /* tapcli: `stop`
+    StopDaemon will send a shutdown request to the interrupt handler, triggering
+    a graceful shutdown of the daemon.
+    */
+    rpc StopDaemon (StopRequest) returns (StopResponse);
+
+    /* tapcli: `debuglevel`
+    DebugLevel allows a caller to programmatically set the logging verbosity of
+    tapd. The logging can be targeted according to a coarse daemon-wide logging
+    level, or in a granular fashion to specify the logging for a target
+    sub-system.
+    */
+    rpc DebugLevel (DebugLevelRequest) returns (DebugLevelResponse);
+
+    /* tapcli: `addrs query`
+    QueryAddrs queries the set of Taproot Asset addresses stored in the
+    database.
+    */
+    rpc QueryAddrs (QueryAddrRequest) returns (QueryAddrResponse);
+
+    /* tapcli: `addrs new`
+    NewAddr makes a new address from the set of request params.
+    */
+    rpc NewAddr (NewAddrRequest) returns (Addr);
+
+    /* tapcli: `addrs decode`
+    DecodeAddr decode a Taproot Asset address into a partial asset message that
+    represents the asset it wants to receive.
+    */
+    rpc DecodeAddr (DecodeAddrRequest) returns (Addr);
+
+    /* tapcli: `addrs receives`
+    List all receives for incoming asset transfers for addresses that were
+    created previously.
+    */
+    rpc AddrReceives (AddrReceivesRequest) returns (AddrReceivesResponse);
+
+    /* tapcli: `proofs verify`
+    VerifyProof attempts to verify a given proof file that claims to be anchored
+    at the specified genesis point.
+    */
+    rpc VerifyProof (ProofFile) returns (ProofVerifyResponse);
+
+    /* tapcli: `proofs export`
+    ExportProof exports the latest raw proof file anchored at the specified
+    script_key.
+    */
+    rpc ExportProof (ExportProofRequest) returns (ProofFile);
+
+    /* tapcli: `proofs import`
+    ImportProof attempts to import a proof file into the daemon. If successful,
+    a new asset will be inserted on disk, spendable using the specified target
+    script key, and internal key.
+    */
+    rpc ImportProof (ImportProofRequest) returns (ImportProofResponse);
+
+    /* tapcli: `assets send`
+    SendAsset uses one or multiple passed Taproot Asset address(es) to attempt
+    to complete an asset send. The method returns information w.r.t the on chain
+    send, as well as the proof file information the receiver needs to fully
+    receive the asset.
+    */
+    rpc SendAsset (SendAssetRequest) returns (SendAssetResponse);
+
+    /*
+    SubscribeSendAssetEventNtfns registers a subscription to the event
+    notification stream which relates to the asset sending process.
+    */
+    rpc SubscribeSendAssetEventNtfns (SubscribeSendAssetEventNtfnsRequest)
+        returns (stream SendAssetEvent);
+
+    /*
+    FetchAssetMeta allows a caller to fetch the reveal meta data for an asset
+    either by the asset ID for that asset, or a meta hash.
+    */
+    rpc FetchAssetMeta (FetchAssetMetaRequest) returns (AssetMeta);
+}
+
+enum AssetType {
+    /*
+    Indicates that an asset is capable of being split/merged, with each of the
+    units being fungible, even across a key asset ID boundary (assuming the
+    key group is the same).
+    */
+    NORMAL = 0;
+
+    /*
+    Indicates that an asset is a collectible, meaning that each of the other
+    items under the same key group are not fully fungible with each other.
+    Collectibles also cannot be split or merged.
+    */
+    COLLECTIBLE = 1;
+}
+
+enum AssetMetaType {
+    /*
+    Opaque is used for asset meta blobs that have no true structure and instead
+    should be interpreted as opaque blobs.
+    */
+    MTEA_TYPE_OPAQUE = 0;
+}
+
+message AssetMeta {
+    /*
+    The raw data of the asset meta data. Based on the type below, this may be
+    structured data such as a text file or PDF.
+    */
+    bytes data = 1;
+
+    // The type of the asset meta data.
+    AssetMetaType type = 2;
+
+    /*
+    The hash of the meta. This is the hash of the TLV serialization of the meta
+    itself.
+    */
+    bytes meta_hash = 3;
+}
+
+message ListAssetRequest {
+    bool with_witness = 1;
+    bool include_spent = 2;
+}
+
+message AnchorInfo {
+    // The transaction that anchors the Taproot Asset commitment where the asset
+    //  resides.
+    bytes anchor_tx = 1;
+
+    // The txid of the above transaction.
+    string anchor_txid = 2;
+
+    // The block hash the contains the anchor transaction above.
+    bytes anchor_block_hash = 3;
+
+    // The outpoint (txid:vout) that stores the Taproot Asset commitment.
+    string anchor_outpoint = 4;
+
+    /*
+    The raw internal key that was used to create the anchor Taproot output key.
+    */
+    bytes internal_key = 5;
+
+    /*
+    The Taproot merkle root hash of the anchor output the asset was committed
+    to. If there is no Tapscript sibling, this is equal to the Taproot Asset
+    root commitment hash.
+    */
+    bytes merkle_root = 6;
+
+    /*
+    The serialized preimage of a Tapscript sibling, if there was one. If this
+    is empty, then the merkle_root hash is equal to the Taproot root hash of the
+    anchor output.
+    */
+    bytes tapscript_sibling = 7;
+}
+
+message GenesisInfo {
+    // The first outpoint of the transaction that created the asset (txid:vout).
+    string genesis_point = 1;
+
+    // The name of the asset.
+    string name = 2;
+
+    // The hash of the meta data for this genesis asset.
+    bytes meta_hash = 3;
+
+    // The asset ID that uniquely identifies the asset.
+    bytes asset_id = 4;
+
+    /*
+    The index of the output that carries the unique Taproot Asset commitment in
+    the genesis transaction.
+    */
+    uint32 output_index = 5;
+
+    // The version of the Taproot Asset commitment that created this asset.
+    int32 version = 6;
+}
+
+message AssetGroup {
+    // The raw group key which is a normal public key.
+    bytes raw_group_key = 1;
+
+    /*
+    The tweaked group key, which is derived based on the genesis point and also
+    asset type.
+    */
+    bytes tweaked_group_key = 2;
+
+    // A signature over the genesis point using the above key.
+    bytes asset_id_sig = 3;
+}
+
+message Asset {
+    // The version of the Taproot Asset.
+    int32 version = 1;
+
+    // The base genesis information of an asset. This information never changes.
+    GenesisInfo asset_genesis = 2;
+
+    // The type of the asset.
+    AssetType asset_type = 3;
+
+    // The total amount of the asset stored in this Taproot Asset UTXO.
+    uint64 amount = 4;
+
+    // An optional locktime, as with Bitcoin transactions.
+    int32 lock_time = 5;
+
+    // An optional relative lock time, same as Bitcoin transactions.
+    int32 relative_lock_time = 6;
+
+    // The version of the script, only version 0 is defined at present.
+    int32 script_version = 7;
+
+    // The script key of the asset, which can be spent under Taproot semantics.
+    bytes script_key = 9;
+
+    // Indicates whether the script key is known to the wallet of the lnd node
+    // connected to the Taproot Asset daemon.
+    bool script_key_is_local = 10;
+
+    // The information related to the key group of an asset (if it exists).
+    AssetGroup asset_group = 11;
+
+    // Describes where in the chain the asset is currently anchored.
+    AnchorInfo chain_anchor = 12;
+
+    repeated PrevWitness prev_witnesses = 13;
+
+    // Indicates whether the asset has been spent.
+    bool is_spent = 14;
+}
+
+message PrevWitness {
+    PrevInputAsset prev_id = 1;
+
+    repeated bytes tx_witness = 2;
+
+    SplitCommitment split_commitment = 3;
+}
+
+message SplitCommitment {
+    Asset root_asset = 1;
+}
+
+message ListAssetResponse {
+    repeated Asset assets = 1;
+}
+
+message ListUtxosRequest {
+}
+
+message ManagedUtxo {
+    // The outpoint of the UTXO.
+    string out_point = 1;
+
+    // The UTXO amount in satoshis.
+    int64 amt_sat = 2;
+
+    // The internal key used for the on-chain output.
+    bytes internal_key = 3;
+
+    // The Taproot Asset root commitment hash.
+    bytes taproot_asset_root = 4;
+
+    /*
+    The Taproot merkle root hash committed to by the outpoint of this UTXO.
+    If there is no Tapscript sibling, this is equal to the Taproot Asset root
+    commitment hash.
+    */
+    bytes merkle_root = 5;
+
+    // The assets held at this UTXO.
+    repeated Asset assets = 6;
+}
+
+message ListUtxosResponse {
+    // The set of UTXOs managed by the daemon.
+    map<string, ManagedUtxo> managed_utxos = 1;
+}
+
+message ListGroupsRequest {
+}
+
+message AssetHumanReadable {
+    // The ID of the asset.
+    bytes id = 1;
+
+    // The amount of the asset.
+    uint64 amount = 2;
+
+    // An optional locktime, as with Bitcoin transactions.
+    int32 lock_time = 3;
+
+    // An optional relative locktime, as with Bitcoin transactions.
+    int32 relative_lock_time = 4;
+
+    // The name of the asset.
+    string tag = 5;
+
+    // The metadata hash of the asset.
+    bytes meta_hash = 6;
+
+    // The type of the asset.
+    AssetType type = 7;
+}
+
+message GroupedAssets {
+    // A list of assets with the same group key.
+    repeated AssetHumanReadable assets = 1;
+}
+
+message ListGroupsResponse {
+    // The set of assets with a group key.
+    map<string, GroupedAssets> groups = 1;
+}
+
+message ListBalancesRequest {
+    oneof group_by {
+        // Group results by asset IDs.
+        bool asset_id = 1;
+
+        // Group results by group keys.
+        bool group_key = 2;
+    }
+
+    // If the query results should grouped by asset ids, then an optional asset
+    // filter may be provided to query balance of a specific asset.
+    bytes asset_filter = 3;
+
+    // If the query results should be grouped by group keys, then an optional
+    // group key filter may be provided to query the balance of a specific
+    // asset group.
+    bytes group_key_filter = 4;
+}
+
+message AssetBalance {
+    // The base genesis information of an asset. This information never changes.
+    GenesisInfo asset_genesis = 1;
+
+    // The type of the asset.
+    AssetType asset_type = 2;
+
+    // The balance of the asset owned by the target daemon.
+    uint64 balance = 3;
+}
+
+message AssetGroupBalance {
+    // The group key or nil aggregating assets that don't have a group.
+    bytes group_key = 1;
+
+    // The total balance of the assets in the group.
+    uint64 balance = 2;
+}
+
+message ListBalancesResponse {
+    map<string, AssetBalance> asset_balances = 1;
+
+    map<string, AssetGroupBalance> asset_group_balances = 2;
+}
+
+message ListTransfersRequest {
+}
+
+message ListTransfersResponse {
+    // The unordered list of outgoing asset transfers.
+    repeated AssetTransfer transfers = 1;
+}
+
+message AssetTransfer {
+    int64 transfer_timestamp = 1;
+
+    // The new transaction that commits to the set of Taproot Assets found
+    // at the above new anchor point.
+    bytes anchor_tx_hash = 2;
+
+    uint32 anchor_tx_height_hint = 3;
+
+    int64 anchor_tx_chain_fees = 4;
+
+    // Describes the set of spent assets.
+    repeated TransferInput inputs = 5;
+
+    // Describes the set of newly created asset outputs.
+    repeated TransferOutput outputs = 6;
+}
+
+message TransferInput {
+    // The old/current location of the Taproot Asset commitment that was spent
+    // as an input.
+    string anchor_point = 1;
+
+    // The ID of the asset that was spent.
+    bytes asset_id = 2;
+
+    // The script key of the asset that was spent.
+    bytes script_key = 3;
+
+    // The amount of the asset that was spent.
+    uint64 amount = 4;
+}
+
+message TransferOutputAnchor {
+    // The new location of the Taproot Asset commitment that was created on
+    // chain.
+    string outpoint = 1;
+
+    int64 value = 2;
+
+    bytes internal_key = 3;
+
+    bytes taproot_asset_root = 4;
+
+    bytes merkle_root = 5;
+
+    bytes tapscript_sibling = 6;
+
+    uint32 num_passive_assets = 7;
+}
+
+enum OutputType {
+    // OUTPUT_TYPE_SIMPLE is a plain full-value or split output that is not a
+    // split root and does not carry passive assets. In case of a split, the
+    // asset of this output has a split commitment.
+    OUTPUT_TYPE_SIMPLE = 0;
+
+    // OUTPUT_TYPE_SPLIT_ROOT is a split root output that carries the change
+    // from a split or a tombstone from a non-interactive full value send
+    // output. In either case, the asset of this output has a tx witness.
+    OUTPUT_TYPE_SPLIT_ROOT = 1;
+
+    // OUTPUT_TYPE_PASSIVE_ASSETS_ONLY indicates that this output only carries
+    // passive assets and therefore the asset in this output is nil. The passive
+    // assets themselves are signed in their own virtual transactions and
+    // are not present in this packet.
+    OUTPUT_TYPE_PASSIVE_ASSETS_ONLY = 2;
+
+    // OUTPUT_TYPE_PASSIVE_SPLIT_ROOT is a split root output that carries the
+    // change from a split or a tombstone from a non-interactive full value send
+    // output, as well as passive assets.
+    OUTPUT_TYPE_PASSIVE_SPLIT_ROOT = 3;
+}
+
+message TransferOutput {
+    TransferOutputAnchor anchor = 1;
+
+    bytes script_key = 2;
+
+    bool script_key_is_local = 3;
+
+    uint64 amount = 4;
+
+    bytes new_proof_blob = 5;
+
+    bytes split_commit_root_hash = 6;
+
+    OutputType output_type = 7;
+}
+
+message StopRequest {
+}
+
+message StopResponse {
+}
+
+message DebugLevelRequest {
+    // If true, all the valid debug sub-systems will be returned.
+    bool show = 1;
+
+    string level_spec = 2;
+}
+message DebugLevelResponse {
+    string sub_systems = 1;
+}
+
+message Addr {
+    // The bech32 encoded Taproot Asset address.
+    string encoded = 1;
+
+    // The asset ID that uniquely identifies the asset.
+    bytes asset_id = 2;
+
+    // The type of the asset.
+    AssetType asset_type = 3;
+
+    // The total amount of the asset stored in this Taproot Asset UTXO.
+    uint64 amount = 4;
+
+    // The group key of the asset (if it exists)
+    bytes group_key = 5;
+
+    /*
+    The specific script key the asset must commit to in order to transfer
+    ownership to the creator of the address.
+    */
+    bytes script_key = 6;
+
+    // The internal key used for the on-chain output.
+    bytes internal_key = 7;
+
+    /*
+    The optional serialized tapscript sibling preimage to use for the receiving
+    asset. This is usually empty as it is only needed when there should be an
+    additional script path in the Taproot tree alongside the Taproot Asset
+    commitment of the asset.
+    */
+    bytes tapscript_sibling = 8;
+
+    /*
+    The tweaked internal key that commits to the asset and represents the
+    on-chain output key the Bitcoin transaction must send to in order to
+    transfer assets described in this address.
+    */
+    bytes taproot_output_key = 9;
+}
+
+message QueryAddrRequest {
+    /*
+    If set, then only addresses created after this Unix timestamp will be
+    returned.
+    */
+    int64 created_after = 1;
+
+    /*
+    If set, then only addresses created before this Unix timestamp will be
+    returned.
+    */
+    int64 created_before = 2;
+
+    // The max number of addresses that should be returned.
+    int32 limit = 3;
+
+    // The offset from the addresses that should be returned.
+    int32 offset = 4;
+}
+
+message QueryAddrResponse {
+    repeated Addr addrs = 1;
+}
+
+message NewAddrRequest {
+    bytes asset_id = 1;
+
+    uint64 amt = 2;
+
+    /*
+    The optional script key that the receiving asset should be locked to. If no
+    script key is provided, a normal BIP-86 key will be derived from the
+    underlying wallet.
+
+    NOTE: The script_key and internal_key fields should either both be set or
+    both be empty.
+    */
+    ScriptKey script_key = 3;
+
+    /*
+    The optional internal key of the receiving BTC level transaction output on
+    which the receiving asset transfers will be committed to. If no internal key
+    is provided, a key will be derived from the underlying wallet.
+
+    NOTE: The script_key and internal_key fields should either both be set or
+    both be empty.
+    */
+    KeyDescriptor internal_key = 4;
+
+    /*
+    The optional serialized tapscript sibling preimage to use for the receiving
+    asset. This is usually empty as it is only needed when there should be an
+    additional script path in the Taproot tree alongside the Taproot Asset
+    commitment of the asset.
+    */
+    bytes tapscript_sibling = 5;
+}
+
+message ScriptKey {
+    /*
+    The full Taproot output key the asset is locked to. This is either a BIP-86
+    key if the tap_tweak below is empty, or a key with the tap tweak applied to
+    it.
+    */
+    bytes pub_key = 1;
+
+    /*
+    The key descriptor describing the internal key of the above Taproot key.
+    */
+    KeyDescriptor key_desc = 2;
+
+    /*
+    The optional Taproot tweak to apply to the above internal key. If this is
+    empty then a BIP-86 style tweak is applied to the internal key.
+    */
+    bytes tap_tweak = 3;
+}
+
+message KeyLocator {
+    /*
+    The family of key being identified.
+    */
+    int32 key_family = 1;
+
+    /*
+    The precise index of the key being identified.
+    */
+    int32 key_index = 2;
+}
+
+message KeyDescriptor {
+    /*
+    The raw bytes of the key being identified.
+    */
+    bytes raw_key_bytes = 1;
+
+    /*
+    The key locator that identifies which key to use for signing.
+    */
+    KeyLocator key_loc = 2;
+}
+
+message DecodeAddrRequest {
+    string addr = 1;
+}
+
+message ProofFile {
+    bytes raw_proof = 1;
+
+    string genesis_point = 2;
+}
+
+message ProofVerifyResponse {
+    bool valid = 1;
+}
+
+message ExportProofRequest {
+    bytes asset_id = 1;
+    bytes script_key = 2;
+
+    // TODO(roasbeef): specify information to make new state transition in proof
+    // file?
+}
+
+message ImportProofRequest {
+    bytes proof_file = 1;
+
+    string genesis_point = 2;
+}
+
+message ImportProofResponse {
+}
+
+enum AddrEventStatus {
+    ADDR_EVENT_STATUS_UNKNOWN = 0;
+    ADDR_EVENT_STATUS_TRANSACTION_DETECTED = 1;
+    ADDR_EVENT_STATUS_TRANSACTION_CONFIRMED = 2;
+    ADDR_EVENT_STATUS_PROOF_RECEIVED = 3;
+    ADDR_EVENT_STATUS_COMPLETED = 4;
+}
+
+message AddrEvent {
+    // The time the event was created in unix timestamp seconds.
+    uint64 creation_time_unix_seconds = 1;
+
+    // The address the event was created for.
+    Addr addr = 2;
+
+    // The current status of the event.
+    AddrEventStatus status = 3;
+
+    // The outpoint that contains the inbound asset transfer.
+    string outpoint = 4;
+
+    /*
+    The amount in satoshis that were transferred on chain along with the asset.
+    This amount is independent of the requested asset amount, which can be
+    looked up on the address.
+    */
+    uint64 utxo_amt_sat = 5;
+
+    /*
+    The taproot sibling hash that was used to send to the Taproot output.
+    */
+    bytes taproot_sibling = 6;
+
+    /*
+    The height at which the on-chain output was confirmed. If this is zero, it
+    means the output is unconfirmed.
+    */
+    uint32 confirmation_height = 7;
+
+    /*
+    Indicates whether a proof file can be found for the address' asset ID and
+    script key.
+    */
+    bool has_proof = 8;
+}
+
+message AddrReceivesRequest {
+    // Filter receives by a specific address. Leave empty to get all receives.
+    string filter_addr = 1;
+
+    // Filter receives by a specific status. Leave empty to get all receives.
+    AddrEventStatus filter_status = 2;
+}
+
+message AddrReceivesResponse {
+    // The events that match the filter criteria.
+    repeated AddrEvent events = 1;
+}
+
+message SendAssetRequest {
+    repeated string tap_addrs = 1;
+
+    // TODO(roasbeef): maybe in future add details re type of ProofCourier or
+    // w/e
+}
+
+message PrevInputAsset {
+    string anchor_point = 1;
+    bytes asset_id = 2;
+    bytes script_key = 3;
+    uint64 amount = 4;
+}
+
+message SendAssetResponse {
+    AssetTransfer transfer = 1;
+}
+
+message SubscribeSendAssetEventNtfnsRequest {
+}
+
+message SendAssetEvent {
+    oneof event {
+        // An event which indicates that a send state is about to be executed.
+        ExecuteSendStateEvent execute_send_state_event = 1;
+
+        // An event which indicates that the proof send backoff wait period will
+        // start imminently.
+        ReceiverProofBackoffWaitEvent receiver_proof_backoff_wait_event = 2;
+    }
+}
+
+message ExecuteSendStateEvent {
+    // Execute timestamp (microseconds).
+    int64 timestamp = 1;
+
+    // The send state that is about to be executed.
+    string send_state = 2;
+}
+
+message ReceiverProofBackoffWaitEvent {
+    // Transfer attempt timestamp (microseconds).
+    int64 timestamp = 1;
+
+    // Backoff is the active backoff wait duration.
+    int64 backoff = 2;
+
+    // Tries counter is the number of tries we've made so far during the
+    // course of the current backoff procedure to deliver the proof to the
+    // receiver.
+    int64 tries_counter = 3;
+}
+
+message FetchAssetMetaRequest {
+    oneof asset {
+        // The asset ID of the asset to fetch the meta for.
+        bytes asset_id = 1;
+
+        // The 32-byte meta hash of the asset meta.
+        bytes meta_hash = 2;
+    }
+}

--- a/protos/tapd/v0.2.0-lit-0/universerpc/universe.proto
+++ b/protos/tapd/v0.2.0-lit-0/universerpc/universe.proto
@@ -1,0 +1,382 @@
+syntax = "proto3";
+
+import "taprootassets.proto";
+
+package universerpc;
+
+option go_package = "github.com/lightninglabs/taproot-assets/taprpc/universerpc";
+
+service Universe {
+    /* tapcli: `universe roots`
+    AssetRoots queries for the known Universe roots associated with each known
+    asset. These roots represent the supply/audit state for each known asset.
+    */
+    rpc AssetRoots (AssetRootRequest) returns (AssetRootResponse);
+
+    /* tapcli: `universe roots`
+    QueryAssetRoots attempts to locate the current Universe root for a specific
+    asset. This asset can be identified by its asset ID or group key.
+    */
+    rpc QueryAssetRoots (AssetRootQuery) returns (QueryRootResponse);
+
+    /* tapcli: `universe keys`
+    AssetLeafKeys queries for the set of Universe keys associated with a given
+    asset_id or group_key. Each key takes the form: (outpoint, script_key),
+    where outpoint is an outpoint in the Bitcoin blockcahin that anchors a
+    valid Taproot Asset commitment, and script_key is the script_key of
+    the asset within the Taproot Asset commitment for the given asset_id or
+    group_key.
+    */
+    rpc AssetLeafKeys (ID) returns (AssetLeafKeyResponse);
+
+    /* tapcli: `universe leaves`
+    AssetLeaves queries for the set of asset leaves (the values in the Universe
+    MS-SMT tree) for a given asset_id or group_key. These represents either
+    asset issuance events (they have a genesis witness) or asset transfers that
+    took place on chain. The leaves contain a normal Taproot Asset proof, as
+    well as details for the asset.
+    */
+    rpc AssetLeaves (ID) returns (AssetLeafResponse);
+
+    /* tapcli: `universe proofs query`
+    QueryProof attempts to query for an issuance or transfer proof for a given
+    asset based on its UniverseKey. A UniverseKey is composed of the Universe
+    ID (asset_id/group_key) and also a leaf key (outpoint || script_key). If
+    found, then the issuance proof is returned that includes an inclusion proof
+    to the known Universe root, as well as a Taproot Asset state transition or
+    issuance proof for the said asset.
+    */
+    rpc QueryProof (UniverseKey) returns (AssetProofResponse);
+
+    // TODO(roasbeef): can make generic by being just AssetProof? ^
+    //   * also want flag to give it in raw bytes so can sideload or import
+
+    /* tapcli: `universe proofs insert`
+    InsertProof attempts to insert a new issuance or transfer proof into the
+    Universe tree specified by the UniverseKey. If valid, then the proof is
+    inserted into the database, with a new Universe root returned for the
+    updated asset_id/group_key.
+    */
+    rpc InsertProof (AssetProof) returns (AssetProofResponse);
+
+    // TODO(roasbeef): rename resp to UniverseStateUpdate? ^
+
+    /* tapcli: `universe sync`
+    SyncUniverse takes host information for a remote Universe server, then
+    attempts to synchronize either only the set of specified asset_ids, or all
+    assets if none are specified. The sync process will attempt to query for
+    the latest known root for each asset, performing tree based reconciliation
+    to arrive at a new shared root.
+    */
+    rpc SyncUniverse (SyncRequest) returns (SyncResponse);
+
+    // TODO(roasebeef): streaming response, so can give feedback? ^
+
+    /* tapcli: `universe federation list`
+    ListFederationServers lists the set of servers that make up the federation
+    of the local Universe server. This servers are used to push out new proofs,
+    and also periodically call sync new proofs from the remote server.
+    */
+    rpc ListFederationServers (ListFederationServersRequest)
+        returns (ListFederationServersResponse);
+
+    /* tapcli: `universe federation add`
+    AddFederationServer adds a new server to the federation of the local
+    Universe server. Once a server is added, this call can also optionally be
+    used to trigger a sync of the remote server.
+    */
+    rpc AddFederationServer (AddFederationServerRequest)
+        returns (AddFederationServerResponse);
+
+    /* tapcli: `universe federation del`
+    DeleteFederationServer removes a server from the federation of the local
+    Universe server.
+    */
+    rpc DeleteFederationServer (DeleteFederationServerRequest)
+        returns (DeleteFederationServerResponse);
+
+    /* tapcli: `universe stats`
+    UniverseStats returns a set of aggregrate statistics for the current state
+    of the Universe. Stats returned include: total number of syncs, total
+    number of proofs, and total number of known assets.
+    */
+    rpc UniverseStats (StatsRequest) returns (StatsResponse);
+
+    /* tapcli `universe stats assets`
+    QueryAssetStats returns a set of statistics for a given set of assets.
+    Stats can be queried for all assets, or based on the: asset ID, name, or
+    asset type. Pagination is supported via the offset and limit params.
+    Results can also be sorted based on any of the main query params.
+    */
+    rpc QueryAssetStats (AssetStatsQuery) returns (UniverseAssetStats);
+}
+
+message AssetRootRequest {
+    // TODO(roasbeef): filter by asset ID, etc?
+}
+
+message MerkleSumNode {
+    // The MS-SMT root hash for the branch node.
+    bytes root_hash = 1;
+
+    // The root sum of the branch node. This is hashed to create the root_hash
+    // along with the left and right siblings. This value represents the total
+    // known supply of the asset.
+    int64 root_sum = 2;
+
+    // TODO(roasbeef): add left and right siblings? then can have full tree
+    // exposed via iterative queries
+}
+
+message ID {
+    oneof id {
+        // The 32-byte asset ID.
+        bytes asset_id = 1;
+
+        // The 32-byte asset ID encoded as a hex string.
+        string asset_id_str = 2;
+
+        // The 32-byte asset group key.
+        bytes group_key = 3;
+
+        // The 32-byte asset group key encoded as hex string.
+        string group_key_str = 4;
+    }
+}
+
+message UniverseRoot {
+    ID id = 1;
+
+    // The merkle sum sparse merkle tree root associated with the above
+    // universe ID.
+    MerkleSumNode mssmt_root = 3;
+
+    // The name of the asset.
+    string asset_name = 4;
+}
+
+message AssetRootResponse {
+    // A map of the set of known universe roots for each asset. The key in the
+    // map is the 32-byte asset_id or group key hash.
+    map<string, UniverseRoot> universe_roots = 1;
+}
+
+message AssetRootQuery {
+    // An ID value to uniquely identify a Universe root.
+    ID id = 1;
+}
+
+message QueryRootResponse {
+    // The asset root for the given asset ID or group key.
+    UniverseRoot asset_root = 1;
+}
+
+message Outpoint {
+    // The output as a hex encoded (and reversed!) string.
+    string hash_str = 1;
+
+    // The index of the output.
+    int32 index = 2;
+}
+
+message AssetKey {
+    // The outpoint of the asset key, either as a single hex encoded string, or
+    // an unrolled outpoint.
+    oneof outpoint {
+        string op_str = 1;
+
+        Outpoint op = 2;
+    }
+
+    // The script key of the asset.
+    oneof script_key {
+        bytes script_key_bytes = 3;
+
+        string script_key_str = 4;
+    }
+}
+
+message AssetLeafKeyResponse {
+    // The set of asset leaf keys for the given asset ID or group key.
+    repeated AssetKey asset_keys = 1;
+}
+
+message AssetLeaf {
+    // The asset included in the leaf.
+    taprpc.Asset asset = 1;
+
+    // TODO(roasbeef): only needed for display? can get from proof below ^
+
+    // The asset issuance proof, which proves that the asset specified above
+    // was issued properly.
+    bytes issuance_proof = 2;
+}
+
+message AssetLeafResponse {
+    // The set of asset leaves for the given asset ID or group key.
+    repeated AssetLeaf leaves = 1;
+}
+
+message UniverseKey {
+    // The ID of the asset to query for.
+    ID id = 1;
+
+    // The asset key to query for.
+    AssetKey leaf_key = 2;
+
+    // TODO(roasbeef): want to be able to eventually do sparse queries? so just
+    // outpoint, then return rest, etc
+}
+
+message AssetProofResponse {
+    // The request original request for the issuance proof.
+    UniverseKey req = 1;
+
+    // The Universe root that includes this asset leaf.
+    UniverseRoot universe_root = 2;
+
+    // An inclusion proof for the asset leaf included below. The value is that
+    // issuance proof itself, with a sum value of the amount of the asset.
+    bytes universe_inclusion_proof = 3;
+
+    // The asset leaf itself, which includes the asset and the issuance proof.
+    AssetLeaf asset_leaf = 4;
+}
+
+message AssetProof {
+    // The ID of the asset to insert the proof for.
+    UniverseKey key = 1;
+
+    // The asset leaf to insert into the Universe tree.
+    AssetLeaf asset_leaf = 4;
+}
+
+enum UniverseSyncMode {
+    // A sync node that indicates that only new asset creation (minting) proofs
+    // should be synced.
+    SYNC_ISSUANCE_ONLY = 0;
+
+    // A syncing mode that indicates that all asset proofs should be synced.
+    // This includes normal transfers as well.
+    SYNC_FULL = 1;
+}
+
+message SyncTarget {
+    ID id = 1;
+}
+
+message SyncRequest {
+    // TODO(roasbeef): accept connection type? so can pass along self-signed
+    // cert, also brontide based RPC handshake
+    string universe_host = 1;
+
+    // The sync mode. This determines what type of proofs are synced.
+    UniverseSyncMode sync_mode = 2;
+
+    // The set of assets to sync. If none are specified, then all assets are
+    // synced.
+    repeated SyncTarget sync_targets = 3;
+}
+
+message SyncedUniverse {
+    // The old Universe root for the synced asset.
+    UniverseRoot old_asset_root = 1;
+
+    // The new Universe root for the synced asset.
+    UniverseRoot new_asset_root = 2;
+
+    // The set of new asset leaves that were synced.
+    repeated AssetLeaf new_asset_leaves = 3;
+}
+
+message StatsRequest {
+}
+
+message SyncResponse {
+    // The set of synced asset Universes.
+    repeated SyncedUniverse synced_universes = 1;
+}
+
+message UniverseFederationServer {
+    string host = 1;
+    int32 id = 2;
+}
+
+message ListFederationServersRequest {
+}
+
+message ListFederationServersResponse {
+    repeated UniverseFederationServer servers = 1;
+}
+
+message AddFederationServerRequest {
+    repeated UniverseFederationServer servers = 1;
+}
+
+message AddFederationServerResponse {
+}
+
+message DeleteFederationServerRequest {
+    repeated UniverseFederationServer servers = 1;
+}
+
+message DeleteFederationServerResponse {
+}
+
+message StatsResponse {
+    int64 num_total_assets = 1;
+    int64 num_total_syncs = 2;
+    int64 num_total_proofs = 3;
+}
+
+enum AssetQuerySort {
+    SORT_BY_NONE = 0;
+
+    SORT_BY_ASSET_NAME = 1;
+
+    SORT_BY_ASSET_ID = 2;
+
+    SORT_BY_ASSET_TYPE = 3;
+}
+
+enum AssetTypeFilter {
+    FILTER_ASSET_NONE = 0;
+
+    FILTER_ASSET_NORMAL = 1;
+
+    FILTER_ASSET_COLLECTIBLE = 2;
+}
+
+message AssetStatsQuery {
+    string asset_name_filter = 1;
+
+    bytes asset_id_filter = 2;
+
+    AssetTypeFilter asset_type_filter = 3;
+
+    AssetQuerySort sort_by = 4;
+
+    int32 offset = 5;
+
+    int32 limit = 6;
+}
+
+message AssetStatsSnapshot {
+    bytes asset_id = 1;
+
+    int64 total_supply = 2;
+
+    string asset_name = 3;
+
+    taprpc.AssetType asset_type = 4;
+
+    int32 genesis_height = 5;
+
+    int64 total_syncs = 6;
+
+    int64 total_proofs = 7;
+}
+
+message UniverseAssetStats {
+    repeated AssetStatsSnapshot asset_stats = 1;
+}

--- a/scripts/generate_types.sh
+++ b/scripts/generate_types.sh
@@ -7,13 +7,15 @@ LND_RELEASE_TAG=$1
 LOOP_RELEASE_TAG=$2
 POOL_RELEASE_TAG=$3
 FARADAY_RELEASE_TAG=$4
-LIT_RELEASE_TAG=$5
-PROTOC_VERSION=$6
+TAPD_RELEASE_TAG=$5
+LIT_RELEASE_TAG=$6
+PROTOC_VERSION=$7
 
 echo "LND release tag:" $LND_RELEASE_TAG
 echo "Loop release tag:" $LOOP_RELEASE_TAG
 echo "Pool release tag:" $POOL_RELEASE_TAG
 echo "Faraday release tag:" $FARADAY_RELEASE_TAG
+echo "Taproot Assets release tag:" $TAPD_RELEASE_TAG
 echo "LiT release tag:" $LIT_RELEASE_TAG
 echo "Protoc version:" $PROTOC_VERSION
 
@@ -106,6 +108,18 @@ protoc/bin/protoc \
   $TS_PROTO_OPTIONS \
   faraday.proto
 
+echo "TAPD: running protoc..."
+mkdir -p "$GENERATED_TYPES_DIR/tapd"
+protoc/bin/protoc \
+  --proto_path=protos/tapd/${TAPD_RELEASE_TAG} \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto \
+  --ts_proto_out=$GENERATED_TYPES_DIR/tapd \
+  $TS_PROTO_OPTIONS \
+  taprootassets.proto \
+  assetwalletrpc/assetwallet.proto \
+  mintrpc/mint.proto \
+  universerpc/universe.proto
+
 echo "LiT: running protoc..."
 mkdir -p "$GENERATED_TYPES_DIR/lit"
 protoc/bin/protoc \
@@ -181,6 +195,18 @@ protoc/bin/protoc \
   --ts_proto_out=$SCHEMA_DIR/faraday \
   $SCHEMA_PROTO_OPTIONS \
   faraday.proto
+
+echo "TAPD: generating schema..."
+mkdir -p "$SCHEMA_DIR/tapd"
+protoc/bin/protoc \
+  --proto_path=protos/tapd/${TAPD_RELEASE_TAG} \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto \
+  --ts_proto_out=$SCHEMA_DIR/tapd \
+  $SCHEMA_PROTO_OPTIONS \
+  taprootassets.proto \
+  assetwalletrpc/assetwallet.proto \
+  mintrpc/mint.proto \
+  universerpc/universe.proto
 
 echo "LIT: generating schema..."
 mkdir -p "$SCHEMA_DIR/lit"

--- a/scripts/update_protos.sh
+++ b/scripts/update_protos.sh
@@ -2,12 +2,14 @@ LND_RELEASE_TAG=$1
 LOOP_RELEASE_TAG=$2
 POOL_RELEASE_TAG=$3
 FARADAY_RELEASE_TAG=$4
-LIT_RELEASE_TAG=$5
+TAPD_RELEASE_TAG=$5
+LIT_RELEASE_TAG=$6
 
 echo "LND release tag:" $LND_RELEASE_TAG
 echo "Loop release tag:" $LOOP_RELEASE_TAG
 echo "Pool release tag:" $POOL_RELEASE_TAG
 echo "Faraday release tag:" $FARADAY_RELEASE_TAG
+echo "Taproot Assets release tag:" $TAPD_RELEASE_TAG
 echo "LiT release tag:" $LIT_RELEASE_TAG
 
 # RPC Servers
@@ -15,6 +17,7 @@ LND_URL="https://raw.githubusercontent.com/lightningnetwork/lnd"
 LOOP_URL="https://raw.githubusercontent.com/lightninglabs/loop"
 POOL_URL="https://raw.githubusercontent.com/lightninglabs/pool"
 FARADAY_URL="https://raw.githubusercontent.com/lightninglabs/faraday"
+TAPD_URL="https://raw.githubusercontent.com/lightninglabs/taproot-assets"
 LIT_URL="https://raw.githubusercontent.com/lightninglabs/lightning-terminal"
 
 curl ${LND_URL}/${LND_RELEASE_TAG}/lnrpc/lightning.proto --create-dirs -o protos/lnd/${LND_RELEASE_TAG}/lightning.proto
@@ -38,6 +41,11 @@ curl ${POOL_URL}/${POOL_RELEASE_TAG}/auctioneerrpc/auctioneer.proto --create-dir
 curl ${POOL_URL}/${POOL_RELEASE_TAG}/auctioneerrpc/hashmail.proto --create-dirs -o protos/pool/${POOL_RELEASE_TAG}/auctioneerrpc/hashmail.proto
 
 curl ${FARADAY_URL}/${FARADAY_RELEASE_TAG}/frdrpc/faraday.proto --create-dirs -o protos/faraday/${FARADAY_RELEASE_TAG}/faraday.proto
+
+curl ${TAPD_URL}/${TAPD_RELEASE_TAG}/taprpc/taprootassets.proto --create-dirs -o protos/tapd/${TAPD_RELEASE_TAG}/taprootassets.proto
+curl ${TAPD_URL}/${TAPD_RELEASE_TAG}/taprpc/assetwalletrpc/assetwallet.proto --create-dirs -o protos/tapd/${TAPD_RELEASE_TAG}/assetwalletrpc/assetwallet.proto
+curl ${TAPD_URL}/${TAPD_RELEASE_TAG}/taprpc/mintrpc/mint.proto --create-dirs -o protos/tapd/${TAPD_RELEASE_TAG}/mintrpc/mint.proto
+curl ${TAPD_URL}/${TAPD_RELEASE_TAG}/taprpc/universerpc/universe.proto --create-dirs -o protos/tapd/${TAPD_RELEASE_TAG}/universerpc/universe.proto
 
 curl ${LIT_URL}/${LIT_RELEASE_TAG}/litrpc/firewall.proto --create-dirs -o protos/lit/${LIT_RELEASE_TAG}/firewall.proto
 curl ${LIT_URL}/${LIT_RELEASE_TAG}/litrpc/lit-sessions.proto --create-dirs -o protos/lit/${LIT_RELEASE_TAG}/lit-sessions.proto


### PR DESCRIPTION
Adds support for the Taproot Assets Protocol Daemon (tapd) RPCs.

See https://github.com/lightninglabs/lnc-web/pull/84 for instructions to test this.