### PR TITLE
scripts: Replace sh with bash to fix syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "dev": "webpack --watch --stats-error-details",
-    "update-protos": "sh scripts/update_protos.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_tapd_release_tag} ${npm_package_config_lit_release_tag}",
-    "generate": "sh scripts/generate_types.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_tapd_release_tag} ${npm_package_config_lit_release_tag} ${npm_package_config_protoc_version}",
+    "update-protos": "bash scripts/update_protos.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_tapd_release_tag} ${npm_package_config_lit_release_tag}",
+    "generate": "bash scripts/generate_types.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_loop_release_tag} ${npm_package_config_pool_release_tag} ${npm_package_config_faraday_release_tag} ${npm_package_config_tapd_release_tag} ${npm_package_config_lit_release_tag} ${npm_package_config_protoc_version}",
     "prettier": "prettier --check '**/*.ts*'",
     "prettier-write": "prettier --check --write '**/*.ts*'",
     "lint": "tslint -p tsconfig.json",

--- a/scripts/generate_types.sh
+++ b/scripts/generate_types.sh
@@ -36,9 +36,9 @@ esac
 
 mkdir -p protoc
 if [[ $platform == 'Linux' ]]; then
-    PROTOC_URL="https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+    PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
 elif [[ $platform == 'Mac' ]]; then
-    PROTOC_URL="https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-x86_64.zip"
+    PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-x86_64.zip"
 else
     echo "Cannot download protoc. ${platform} is not currently supported by ts-protoc-gen"
     exit 1
@@ -129,7 +129,7 @@ protoc/bin/protoc \
   $TS_PROTO_OPTIONS \
   firewall.proto \
   lit-sessions.proto \
-  lit-autopilot.proto 
+  lit-autopilot.proto
 
 # Temporarily generate schema files in order to provide metadata
 # about the services and subscription methods to the api classes
@@ -217,7 +217,7 @@ protoc/bin/protoc \
   $SCHEMA_PROTO_OPTIONS \
   firewall.proto \
   lit-sessions.proto \
-  lit-autopilot.proto 
+  lit-autopilot.proto
 
 # Cleanup proto directory/files
 rm -rf *.proto protoc


### PR DESCRIPTION
```
scripts/generate_types.sh: 36: [[: not found
scripts/generate_types.sh: 38: [[: not found
Cannot download protoc. Linux is not currently supported by ts-protoc-gen
```

I ran into this bug while trying to generate new proto files on Linux. It turns out `sh` does not support the `[[ ... ]]` syntax, but `bash` does.

![Screenshot from 2023-06-16 03-21-51](https://github.com/lightninglabs/lnc-core/assets/1670549/5fa3765c-e19a-495d-840e-6c9466e63c01)
