### PR TITLE
Bump litd to v0.12.0-alpha

### DIFF
--- a/lib/types/proto/lit/firewall.ts
+++ b/lib/types/proto/lit/firewall.ts
@@ -23,10 +23,17 @@ export interface PrivacyMapConversionRequest {
      * string will be assumed to be the pseudo value.
      */
     realToPseudo: boolean;
-    /** The session ID under which to search for the real-pseudo pair. */
+    /**
+     * Deprecated, use group_id.
+     * The session ID under which to search for the real-pseudo pair.
+     *
+     * @deprecated
+     */
     sessionId: Uint8Array | string;
     /** The input to be converted into the real or pseudo value. */
     input: string;
+    /** The group ID under which to search for the real-pseudo pair. */
+    groupId: Uint8Array | string;
 }
 
 export interface PrivacyMapConversionResponse {
@@ -89,6 +96,8 @@ export interface ListActionsRequest {
      * considered.
      */
     endTimestamp: string;
+    /** If specified, then only actions under the given group will be queried. */
+    groupId: Uint8Array | string;
 }
 
 export interface ListActionsResponse {

--- a/lib/types/proto/lit/lit-autopilot.ts
+++ b/lib/types/proto/lit/lit-autopilot.ts
@@ -27,6 +27,8 @@ export interface AddAutopilotSessionRequest {
     sessionRules: RulesMap | undefined;
     /** Set to true of the session should not make use of the privacy mapper. */
     noPrivacyMapper: boolean;
+    /** Set to the ID of the group to link this session to, if any. */
+    linkedGroupId: Uint8Array | string;
 }
 
 export interface AddAutopilotSessionRequest_FeaturesEntry {
@@ -98,6 +100,8 @@ export interface Feature {
      * feature rules set contains a rule that Litd is unaware of.
      */
     requiresUpgrade: boolean;
+    /** The JSON-marshaled representation of a feature's default configuration. */
+    defaultConfig: string;
 }
 
 export interface Feature_RulesEntry {

--- a/lib/types/proto/lit/lit-sessions.ts
+++ b/lib/types/proto/lit/lit-sessions.ts
@@ -128,11 +128,27 @@ export interface Session {
      * not revoked. Readers should instead first check the session_state field.
      */
     revokedAt: string;
+    /**
+     * The ID of the group of Session's that this Session is linked to. If this
+     * session is not linked to any older Session, then this value will be the
+     * same as the ID.
+     */
+    groupId: Uint8Array | string;
+    /**
+     * Configurations for each individual feature mapping from the feature name to
+     * a JSON-serialized configuration.
+     */
+    featureConfigs: { [key: string]: string };
 }
 
 export interface Session_AutopilotFeatureInfoEntry {
     key: string;
     value: RulesMap | undefined;
+}
+
+export interface Session_FeatureConfigsEntry {
+    key: string;
+    value: string;
 }
 
 export interface MacaroonRecipe {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pool_release_tag": "v0.6.4-beta",
     "faraday_release_tag": "v0.2.11-alpha",
     "tapd_release_tag": "v0.2.3",
-    "lit_release_tag": "v0.10.5-alpha",
+    "lit_release_tag": "v0.12.0-alpha",
     "protoc_version": "21.9"
   },
   "scripts": {

--- a/protos/lit/v0.12.0-alpha/firewall.proto
+++ b/protos/lit/v0.12.0-alpha/firewall.proto
@@ -36,14 +36,20 @@ message PrivacyMapConversionRequest {
     bool real_to_pseudo = 1;
 
     /*
+    Deprecated, use group_id.
     The session ID under which to search for the real-pseudo pair.
     */
-    bytes session_id = 2;
+    bytes session_id = 2 [deprecated = true];
 
     /*
     The input to be converted into the real or pseudo value.
     */
     string input = 3;
+
+    /*
+    The group ID under which to search for the real-pseudo pair.
+    */
+    bytes group_id = 4;
 }
 
 message PrivacyMapConversionResponse {
@@ -120,6 +126,11 @@ message ListActionsRequest {
     considered.
     */
     uint64 end_timestamp = 11 [jstype = JS_STRING];
+
+    /*
+    If specified, then only actions under the given group will be queried.
+    */
+    bytes group_id = 12;
 }
 
 message ListActionsResponse {

--- a/protos/lit/v0.12.0-alpha/lit-autopilot.proto
+++ b/protos/lit/v0.12.0-alpha/lit-autopilot.proto
@@ -73,6 +73,11 @@ message AddAutopilotSessionRequest {
     Set to true of the session should not make use of the privacy mapper.
     */
     bool no_privacy_mapper = 7;
+
+    /*
+    Set to the ID of the group to link this session to, if any.
+    */
+    bytes linked_group_id = 8;
 }
 
 message FeatureConfig {
@@ -156,6 +161,11 @@ message Feature {
     feature rules set contains a rule that Litd is unaware of.
     */
     bool requires_upgrade = 5;
+
+    /*
+    The JSON-marshaled representation of a feature's default configuration.
+    */
+    string default_config = 6;
 }
 
 message RuleValues {

--- a/protos/lit/v0.12.0-alpha/lit-sessions.proto
+++ b/protos/lit/v0.12.0-alpha/lit-sessions.proto
@@ -199,6 +199,19 @@ message Session {
     not revoked. Readers should instead first check the session_state field.
     */
     uint64 revoked_at = 16 [jstype = JS_STRING];
+
+    /*
+    The ID of the group of Session's that this Session is linked to. If this
+    session is not linked to any older Session, then this value will be the
+    same as the ID.
+    */
+    bytes group_id = 17;
+
+    /*
+    Configurations for each individual feature mapping from the feature name to
+    a JSON-serialized configuration.
+    */
+    map<string, string> feature_configs = 18;
 }
 
 message MacaroonRecipe {

--- a/protos/lit/v0.12.0-alpha/lit-status.proto
+++ b/protos/lit/v0.12.0-alpha/lit-status.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package litrpc;
+
+option go_package = "github.com/lightninglabs/lightning-terminal/litrpc";
+
+// The Status server can be used to query the state of various LiT sub-servers.
+service Status {
+    rpc SubServerStatus (SubServerStatusReq) returns (SubServerStatusResp);
+}
+
+message SubServerStatusReq {
+}
+
+message SubServerStatusResp {
+    // A map of sub-server names to their status.
+    map<string, SubServerStatus> sub_servers = 1;
+}
+
+message SubServerStatus {
+    // disabled is true if the sub-server is available in the LiT package but
+    // has explicitly been disabled.
+    bool disabled = 1;
+
+    // running is true if the sub-server is currently running.
+    bool running = 2;
+
+    // error describes an error that might have resulted in the sub-server not
+    // starting up properly.
+    string error = 3;
+}

--- a/scripts/update_protos.sh
+++ b/scripts/update_protos.sh
@@ -53,4 +53,5 @@ curl ${TAPD_URL}/${TAPD_RELEASE_TAG}/taprpc/universerpc/universe.proto --create-
 
 curl ${LIT_URL}/${LIT_RELEASE_TAG}/litrpc/firewall.proto --create-dirs -o protos/lit/${LIT_RELEASE_TAG}/firewall.proto
 curl ${LIT_URL}/${LIT_RELEASE_TAG}/litrpc/lit-sessions.proto --create-dirs -o protos/lit/${LIT_RELEASE_TAG}/lit-sessions.proto
+curl ${LIT_URL}/${LIT_RELEASE_TAG}/litrpc/lit-status.proto --create-dirs -o protos/lit/${LIT_RELEASE_TAG}/lit-status.proto
 curl ${LIT_URL}/${LIT_RELEASE_TAG}/litrpc/lit-autopilot.proto --create-dirs -o protos/lit/${LIT_RELEASE_TAG}/lit-autopilot.proto


### PR DESCRIPTION
Replaces #28

This PR updates to the latest version of litd in order to pull in support for autopilot session linking (autopilot `groupId`).

Additionally I noticed that the subserver status proto file wasn't included in the `scripts/update_protos.sh` file, so I updated that as well.