### PR TITLE
Update to lnc-core `v0.2.8-alpha` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-core",
-  "version": "0.2.6-alpha",
+  "version": "0.2.8-alpha",
   "description": "Type definitions and utilities for Lightning Node Connect",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR bumps lnc-core to `v0.2.8-alpha`.