### PR TITLE
Bump version from 0.3.5-alpha to 0.3.6-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-core",
-  "version": "0.3.5-alpha",
+  "version": "0.3.6-alpha",
   "description": "Type definitions and utilities for Lightning Node Connect",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bumping the version to align with the latest `lightning-node-connect` version. There are no functional changes.